### PR TITLE
Add Firebase backend scaffolding

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -1,0 +1,9 @@
+{
+  "functions": {
+    "source": "functions"
+  },
+  "hosting": {
+    "public": "public",
+    "ignore": ["firebase.json", "**/.*", "**/node_modules/**"]
+  }
+}

--- a/firestore.rules
+++ b/firestore.rules
@@ -1,0 +1,12 @@
+rules_version = '2';
+service cloud.firestore {
+  match /databases/{database}/documents {
+    match /users/{userId} {
+      allow read, write: if request.auth != null && request.auth.uid == userId;
+
+      match /{subcollection=**} {
+        allow read, write: if request.auth != null && request.auth.uid == userId;
+      }
+    }
+  }
+}

--- a/functions/index.js
+++ b/functions/index.js
@@ -1,0 +1,30 @@
+const functions = require("firebase-functions");
+const admin = require("firebase-admin");
+
+admin.initializeApp();
+const db = admin.firestore();
+
+exports.generateUserPlan = functions.firestore
+  .document("users/{userId}")
+  .onCreate(async (snap, context) => {
+    const userData = snap.data();
+    const userId = context.params.userId;
+
+    const roadmap = [
+      { phase: "Explore", description: "Research scholarships and internships." },
+      { phase: "Build", description: "Craft tailored resume and apply to 3 targets." },
+      { phase: "Launch", description: "Submit applications and prep for interviews." },
+    ];
+
+    const resume = `Hi, I'm ${userData.fullName}, aiming to achieve ${userData.dreamOutcome}. I bring strengths in leadership, adaptability, and community impact.`;
+
+    const opportunities = [
+      { title: "Future Leaders Scholarship", link: "https://example.com" },
+      { title: "Tech for Impact Internship", link: "https://example.com" },
+      { title: "Equity Accelerator Program", link: "https://example.com" }
+    ];
+
+    await db.collection("users").doc(userId).collection("roadmap").add({ roadmap });
+    await db.collection("users").doc(userId).collection("resume").add({ resume });
+    await db.collection("users").doc(userId).collection("opportunities").add({ opportunities });
+  });

--- a/functions/package.json
+++ b/functions/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "functions",
+  "description": "Firebase Cloud Functions for Opportunity Engine",
+  "engines": {
+    "node": "18"
+  },
+  "dependencies": {
+    "firebase-admin": "^11.0.0",
+    "firebase-functions": "^3.20.1"
+  }
+}

--- a/public/form-handler.js
+++ b/public/form-handler.js
@@ -1,0 +1,22 @@
+// Assumes Firebase SDK already initialized in index.html
+
+function submitOpportunityForm() {
+  const fullName = document.getElementById("fullName").value;
+  const email = document.getElementById("email").value;
+  const zipCode = document.getElementById("zipCode").value;
+  const currentStanding = document.getElementById("currentStanding").value;
+  const dreamOutcome = document.getElementById("dreamOutcome").value;
+
+  firebase.firestore().collection("users").doc(email).set({
+    fullName,
+    email,
+    zipCode,
+    currentStanding,
+    dreamOutcome,
+    createdAt: firebase.firestore.FieldValue.serverTimestamp(),
+  }).then(() => {
+    alert("Form submitted! Your plan is being generated.");
+  }).catch((err) => {
+    console.error("Error saving form:", err);
+  });
+}


### PR DESCRIPTION
## Summary
- add Firebase hosting config
- create Cloud Function to generate user plan
- provide Firestore security rules
- add form submit handler for frontend

## Testing
- `node -v`


------
https://chatgpt.com/codex/tasks/task_e_68646091e0c08323960a16fe38aea130