### PR TITLE
Add basic dashboard interface

### DIFF
--- a/frontend/dashboard.html
+++ b/frontend/dashboard.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>User Dashboard</title>
+  <link rel="stylesheet" href="style.css">
+  <!-- Firebase App (the core Firebase SDK) -->
+  <script src="https://www.gstatic.com/firebasejs/9.6.10/firebase-app-compat.js"></script>
+  <script src="https://www.gstatic.com/firebasejs/9.6.10/firebase-firestore-compat.js"></script>
+</head>
+<body>
+  <div class="container">
+    <h1>Opportunity Dashboard</h1>
+    <div id="roadmap" class="roadmap"></div>
+    <div id="resume" class="resume"></div>
+    <div id="opportunities" class="opportunities"></div>
+  </div>
+  <script src="dashboard.js"></script>
+</body>
+</html>

--- a/frontend/dashboard.js
+++ b/frontend/dashboard.js
@@ -1,0 +1,72 @@
+// Firebase configuration placeholder - replace with your project config
+const firebaseConfig = {
+  apiKey: "YOUR_API_KEY",
+  authDomain: "YOUR_PROJECT_ID.firebaseapp.com",
+  projectId: "YOUR_PROJECT_ID",
+};
+firebase.initializeApp(firebaseConfig);
+const db = firebase.firestore();
+
+function getUserId() {
+  const params = new URLSearchParams(window.location.search);
+  return params.get('id');
+}
+
+function renderRoadmap(steps = []) {
+  const container = document.getElementById('roadmap');
+  container.innerHTML = '<h2>📍 Roadmap</h2>';
+  const timeline = document.createElement('div');
+  timeline.className = 'timeline';
+  steps.slice(0, 3).forEach((step, idx) => {
+    const item = document.createElement('div');
+    item.className = 'timeline-step';
+    item.innerHTML = `<h3>Step ${idx + 1}: ${step.phase}</h3><p>${step.description}</p>`;
+    timeline.appendChild(item);
+  });
+  container.appendChild(timeline);
+}
+
+function renderResume(summary) {
+  const container = document.getElementById('resume');
+  container.innerHTML = `<h2>📄 Resume</h2><p>${summary}</p>`;
+}
+
+function renderOpportunities(list = []) {
+  const container = document.getElementById('opportunities');
+  container.innerHTML = '<h2>🔍 Opportunities</h2>';
+  const grid = document.createElement('div');
+  grid.className = 'opportunity-grid';
+  list.forEach(op => {
+    const card = document.createElement('div');
+    card.className = 'opportunity-card';
+    card.innerHTML = `<h3>${op.title}</h3><p>${op.description || ''}</p><a href="${op.link}" target="_blank">View</a>`;
+    grid.appendChild(card);
+  });
+  container.appendChild(grid);
+}
+
+function initDashboard() {
+  const userId = getUserId();
+  if (!userId) return alert('No user ID provided');
+  const userRef = db.collection('users').doc(userId);
+
+  userRef.collection('roadmap').limit(1).onSnapshot(snapshot => {
+    snapshot.forEach(doc => {
+      renderRoadmap(doc.data().roadmap);
+    });
+  });
+
+  userRef.collection('resume').limit(1).onSnapshot(snapshot => {
+    snapshot.forEach(doc => {
+      renderResume(doc.data().summary);
+    });
+  });
+
+  userRef.collection('opportunities').limit(1).onSnapshot(snapshot => {
+    snapshot.forEach(doc => {
+      renderOpportunities(doc.data().opportunities);
+    });
+  });
+}
+
+document.addEventListener('DOMContentLoaded', initDashboard);

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -1,0 +1,46 @@
+body {
+  font-family: Arial, sans-serif;
+  margin: 0;
+  padding: 0;
+  background: #f5f5f5;
+}
+.container {
+  max-width: 900px;
+  margin: 0 auto;
+  padding: 20px;
+}
+.timeline {
+  display: flex;
+  gap: 10px;
+  margin-bottom: 20px;
+}
+.timeline-step {
+  background: white;
+  border: 1px solid #ddd;
+  flex: 1;
+  padding: 10px;
+  border-radius: 4px;
+}
+.resume {
+  background: white;
+  padding: 15px;
+  border: 1px solid #ddd;
+  border-radius: 4px;
+  margin-bottom: 20px;
+}
+.opportunity-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+  gap: 15px;
+}
+.opportunity-card {
+  background: white;
+  border: 1px solid #ddd;
+  border-radius: 4px;
+  padding: 10px;
+}
+.opportunity-card a {
+  display: inline-block;
+  margin-top: 10px;
+  color: #0366d6;
+}


### PR DESCRIPTION
## Summary
- add user dashboard page with roadmap, resume, and opportunity sections
- include realtime Firestore loading logic
- provide simple grid/flex styles

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_686464b3a64883238ea7c98241c9ca35