### PR TITLE
Add agent logging module

### DIFF
--- a/functions/agents/roadmapAgent.js
+++ b/functions/agents/roadmapAgent.js
@@ -1,9 +1,22 @@
-function generateRoadmap(userData) {
-  return [
+const { logAgentOutput } = require('../logger');
+
+function generateRoadmap(userData, { userId = 'unknown', agentVersion = '1.0.0' } = {}) {
+  const roadmap = [
     { phase: 'Discover', description: 'Research scholarships and career paths.' },
     { phase: 'Build', description: 'Create resume and develop key skills.' },
     { phase: 'Launch', description: 'Apply to programs and prepare for interviews.' }
   ];
+
+  // Log execution details
+  logAgentOutput({
+    agentName: 'roadmap-agent',
+    agentVersion,
+    userId,
+    inputSummary: userData,
+    outputSummary: roadmap
+  });
+
+  return roadmap;
 }
 
 module.exports = { generateRoadmap };

--- a/functions/index.js
+++ b/functions/index.js
@@ -14,7 +14,7 @@ exports.handleNewUser = functions.firestore
     const userData = snap.data();
     const userId = context.params.userId;
 
-    const roadmap = generateRoadmap(userData);
+    const roadmap = generateRoadmap(userData, { userId, agentVersion: '1.0.0' });
     const resume = generateResumeSummary(userData);
     const opportunities = generateOpportunities(userData);
 

--- a/functions/logger.js
+++ b/functions/logger.js
@@ -1,0 +1,59 @@
+const admin = require('firebase-admin');
+const fs = require('fs');
+const path = require('path');
+
+const logFilePath = path.join(__dirname, 'logs.json');
+
+/**
+ * Log agent execution details to Firestore and local file.
+ * @param {Object} params
+ * @param {string} params.agentName
+ * @param {string} params.agentVersion
+ * @param {string} params.userId - UID or email
+ * @param {*} params.inputSummary - Summary of inputs
+ * @param {*} params.outputSummary - Summary of outputs
+ */
+async function logAgentOutput({
+  agentName,
+  agentVersion,
+  userId,
+  inputSummary,
+  outputSummary
+}) {
+  const logEntry = {
+    timestamp: new Date().toISOString(),
+    agentName,
+    agentVersion,
+    userId,
+    inputSummary,
+    outputSummary
+  };
+
+  // Write to Firestore collection 'logs'
+  try {
+    const db = admin.firestore();
+    await db.collection('logs').add(logEntry);
+  } catch (err) {
+    console.error('Failed to write log to Firestore', err);
+  }
+
+  // Append to local logs.json file
+  try {
+    let logs = [];
+    if (fs.existsSync(logFilePath)) {
+      const content = fs.readFileSync(logFilePath, 'utf8');
+      try {
+        logs = JSON.parse(content);
+        if (!Array.isArray(logs)) logs = [];
+      } catch (e) {
+        logs = [];
+      }
+    }
+    logs.push(logEntry);
+    fs.writeFileSync(logFilePath, JSON.stringify(logs, null, 2));
+  } catch (err) {
+    console.error('Failed to write log to local file', err);
+  }
+}
+
+module.exports = { logAgentOutput };

--- a/functions/logger.js
+++ b/functions/logger.js
@@ -1,5 +1,5 @@
 const admin = require('firebase-admin');
-const fs = require('fs');
+const fs = require('fs/promises');
 const path = require('path');
 
 const logFilePath = path.join(__dirname, 'logs.json');
@@ -40,17 +40,17 @@ async function logAgentOutput({
   // Append to local logs.json file
   try {
     let logs = [];
-    if (fs.existsSync(logFilePath)) {
-      const content = fs.readFileSync(logFilePath, 'utf8');
-      try {
-        logs = JSON.parse(content);
-        if (!Array.isArray(logs)) logs = [];
-      } catch (e) {
-        logs = [];
-      }
+    try {
+      const content = await fs.readFile(logFilePath, 'utf8');
+      logs = JSON.parse(content);
+      if (!Array.isArray(logs)) logs = [];
+    } catch (e) {
+      // File might not exist or JSON might be invalid
+      logs = [];
     }
+
     logs.push(logEntry);
-    fs.writeFileSync(logFilePath, JSON.stringify(logs, null, 2));
+    await fs.writeFile(logFilePath, JSON.stringify(logs, null, 2));
   } catch (err) {
     console.error('Failed to write log to local file', err);
   }

--- a/functions/logs.json
+++ b/functions/logs.json
@@ -1,0 +1,10 @@
+[
+  {
+    "timestamp": "2023-01-01T00:00:00.000Z",
+    "agentName": "roadmap-agent",
+    "agentVersion": "1.0.0",
+    "userId": "sample-user",
+    "inputSummary": { "sample": true },
+    "outputSummary": { "roadmap": [] }
+  }
+]


### PR DESCRIPTION
## Summary
- log agent runs to Firestore and `logs.json`
- integrate logger in `roadmapAgent`
- call `roadmapAgent` with metadata
- add sample `logs.json`

## Testing
- `node -e "require('./functions/logger.js'); console.log('logger loaded')"`
- `node -e "require('./functions/index.js'); console.log('index loaded')"`


------
https://chatgpt.com/codex/tasks/task_e_686464c1354483239685953d4e7ae3f3