### PR TITLE
Add agent execution wrapper

### DIFF
--- a/functions/agents/alignment-core.js
+++ b/functions/agents/alignment-core.js
@@ -1,6 +1,3 @@
-const fs = require('fs');
-const path = require('path');
-
 function runAlignmentCheck({ agentName = 'unknown-agent', output, userData = {} }) {
   const flags = [];
   let notes = '';
@@ -33,27 +30,6 @@ function runAlignmentCheck({ agentName = 'unknown-agent', output, userData = {} 
 
   const alignmentPassed = flags.length === 0;
   const result = { alignmentPassed, flags, notes };
-
-  // Write log entry
-  const logPath = path.join(__dirname, '..', 'logs.json');
-  const logEntry = {
-    timestamp: new Date().toISOString(),
-    agentName,
-    alignmentPassed,
-    flags,
-    notes
-  };
-  let logs = [];
-  if (fs.existsSync(logPath)) {
-    try {
-      logs = JSON.parse(fs.readFileSync(logPath, 'utf8'));
-      if (!Array.isArray(logs)) logs = [];
-    } catch (e) {
-      logs = [];
-    }
-  }
-  logs.push(logEntry);
-  fs.writeFileSync(logPath, JSON.stringify(logs, null, 2));
 
   return result;
 }

--- a/functions/agents/opportunityAgent.js
+++ b/functions/agents/opportunityAgent.js
@@ -1,16 +1,19 @@
-const { runAlignmentCheck } = require('./alignment-core');
+const { executeAgent } = require('../utils/agent-wrapper');
 
-function generateOpportunities(userData) {
-  const opportunities = [
-    { title: 'Future Leaders Scholarship', link: 'https://example.com' },
-    { title: 'Tech for Impact Internship', link: 'https://example.com' },
-    { title: 'Equity Accelerator Program', link: 'https://example.com' }
-  ];
-
-  // Run alignment check and log result
-  runAlignmentCheck({ agentName: 'opportunity-agent', output: opportunities, userData });
-
-  return opportunities;
+async function generateOpportunities(userData, userId) {
+  return executeAgent({
+    agentName: 'opportunity-agent',
+    version: 'v1.0.2',
+    userId,
+    input: userData,
+    agentFunction: async () => {
+      return [
+        { title: 'Future Leaders Scholarship', link: 'https://example.com' },
+        { title: 'Tech for Impact Internship', link: 'https://example.com' },
+        { title: 'Equity Accelerator Program', link: 'https://example.com' }
+      ];
+    }
+  });
 }
 
 module.exports = { generateOpportunities };

--- a/functions/agents/resumeAgent.js
+++ b/functions/agents/resumeAgent.js
@@ -1,14 +1,17 @@
-const { runAlignmentCheck } = require('./alignment-core');
+const { executeAgent } = require('../utils/agent-wrapper');
 
-function generateResumeSummary(userData) {
-  const name = userData.fullName || 'User';
-  const outcome = userData.dreamOutcome || 'your desired goal';
-  const summary = `Hi, I'm ${name}. I aim to achieve ${outcome}. I bring strengths in leadership and adaptability.`;
-
-  // Run alignment check and log result
-  runAlignmentCheck({ agentName: 'resume-agent', output: summary, userData });
-
-  return summary;
+async function generateResumeSummary(userData, userId) {
+  return executeAgent({
+    agentName: 'resume-agent',
+    version: 'v1.0.2',
+    userId,
+    input: userData,
+    agentFunction: async (input) => {
+      const name = input.fullName || 'User';
+      const outcome = input.dreamOutcome || 'your desired goal';
+      return `Hi, I'm ${name}. I aim to achieve ${outcome}. I bring strengths in leadership and adaptability.`;
+    }
+  });
 }
 
 module.exports = { generateResumeSummary };

--- a/functions/agents/roadmapAgent.js
+++ b/functions/agents/roadmapAgent.js
@@ -1,16 +1,19 @@
-const { runAlignmentCheck } = require('./alignment-core');
+const { executeAgent } = require('../utils/agent-wrapper');
 
-function generateRoadmap(userData) {
-  const roadmap = [
-    { phase: 'Discover', description: 'Research scholarships and career paths.' },
-    { phase: 'Build', description: 'Create resume and develop key skills.' },
-    { phase: 'Launch', description: 'Apply to programs and prepare for interviews.' }
-  ];
-
-  // Run alignment check and log result
-  runAlignmentCheck({ agentName: 'roadmap-agent', output: roadmap, userData });
-
-  return roadmap;
+async function generateRoadmap(userData, userId) {
+  return executeAgent({
+    agentName: 'roadmap-agent',
+    version: 'v1.0.2',
+    userId,
+    input: userData,
+    agentFunction: async () => {
+      return [
+        { phase: 'Discover', description: 'Research scholarships and career paths.' },
+        { phase: 'Build', description: 'Create resume and develop key skills.' },
+        { phase: 'Launch', description: 'Apply to programs and prepare for interviews.' }
+      ];
+    }
+  });
 }
 
 module.exports = { generateRoadmap };

--- a/functions/index.js
+++ b/functions/index.js
@@ -14,9 +14,9 @@ exports.handleNewUser = functions.firestore
     const userData = snap.data();
     const userId = context.params.userId;
 
-    const roadmap = generateRoadmap(userData);
-    const resume = generateResumeSummary(userData);
-    const opportunities = generateOpportunities(userData);
+    const roadmap = await generateRoadmap(userData, userId);
+    const resume = await generateResumeSummary(userData, userId);
+    const opportunities = await generateOpportunities(userData, userId);
 
     await db.collection('users').doc(userId).collection('roadmap').add({ roadmap });
     await db.collection('users').doc(userId).collection('resume').add({ summary: resume });

--- a/functions/utils/agent-wrapper.js
+++ b/functions/utils/agent-wrapper.js
@@ -1,0 +1,68 @@
+const admin = require('firebase-admin');
+const fs = require('fs');
+const path = require('path');
+const { runAlignmentCheck } = require('../agents/alignment-core');
+
+async function executeAgent({ agentName = 'unknown-agent', version = 'v1.0.0', userId = 'unknown', input = {}, agentFunction }) {
+  const start = new Date();
+  console.log(`[${start.toISOString()}] Starting ${agentName}`);
+
+  let output;
+  let alignment = { alignmentPassed: false, flags: ['agent_error'], notes: '' };
+
+  try {
+    output = await agentFunction(input);
+    alignment = runAlignmentCheck({ agentName, output, userData: input });
+  } catch (err) {
+    alignment.notes = err.message;
+  }
+
+  const status = alignment.alignmentPassed ? 'pass' : 'fail';
+  const timestamp = new Date().toISOString();
+  const outputSummary = typeof output === 'string' ? output.slice(0, 100) : JSON.stringify(output).slice(0, 100);
+
+  const logEntry = {
+    agent: agentName,
+    version,
+    user: userId,
+    status,
+    alignment: { passed: alignment.alignmentPassed, flags: alignment.flags },
+    timestamp,
+    outputSummary
+  };
+
+  // Firestore logging
+  try {
+    const db = admin.firestore();
+    await db.collection('logs').add(logEntry);
+  } catch (e) {
+    console.error('Failed to write log to Firestore:', e.message);
+  }
+
+  // Local fallback logging
+  try {
+    const logPath = path.join(__dirname, '..', 'logs.json');
+    let logs = [];
+    if (fs.existsSync(logPath)) {
+      const raw = fs.readFileSync(logPath, 'utf8');
+      try {
+        logs = JSON.parse(raw);
+        if (!Array.isArray(logs)) logs = [];
+      } catch (_) {
+        logs = [];
+      }
+    }
+    logs.push(logEntry);
+    fs.writeFileSync(logPath, JSON.stringify(logs, null, 2));
+  } catch (e) {
+    console.error('Failed to write local log:', e.message);
+  }
+
+  if (status === 'fail') {
+    return { error: 'Output did not pass alignment checks.' };
+  }
+
+  return output;
+}
+
+module.exports = { executeAgent };


### PR DESCRIPTION
## Summary
- create `agent-wrapper.js` to standardize running agents with alignment filtering and logging
- update roadmap, resume and opportunity agents to use the wrapper
- remove old logging from `alignment-core`
- adjust index function to await new agent calls

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686466a99d808323ab8d0eb9bb5e9127