### PR TITLE
Add opportunity agent logging

### DIFF
--- a/functions/agents/opportunityAgent.js
+++ b/functions/agents/opportunityAgent.js
@@ -1,19 +1,39 @@
 const { executeAgent } = require('../utils/agent-wrapper');
+const { logAgentOutput } = require('../logger');
 
-async function generateOpportunities(userData, userId) {
-  return executeAgent({
+/**
+ * Generate a list of opportunities for the user.
+ * @param {Object} userData - User profile data
+ * @param {string} userId - Firebase UID
+ * @param {Object} metadata - Optional metadata to log
+ */
+async function generateOpportunities(userData = {}, userId = 'unknown', metadata = {}) {
+  const agentVersion = 'v1.0.3';
+
+  const result = await executeAgent({
     agentName: 'opportunity-agent',
-    version: 'v1.0.2',
+    version: agentVersion,
     userId,
     input: userData,
-    agentFunction: async () => {
+    agentFunction: async (input) => {
+      const field = input.focus || 'general';
       return [
-        { title: 'Future Leaders Scholarship', link: 'https://example.com' },
-        { title: 'Tech for Impact Internship', link: 'https://example.com' },
-        { title: 'Equity Accelerator Program', link: 'https://example.com' }
+        { title: `${field} Scholarship`, link: 'https://example.com' },
+        { title: `${field} Internship`, link: 'https://example.com' },
+        { title: `${field} Grant`, link: 'https://example.com' }
       ];
     }
   });
+
+  await logAgentOutput({
+    agentName: 'opportunity-agent',
+    agentVersion,
+    userId,
+    inputSummary: metadata,
+    outputSummary: Array.isArray(result) ? result.map(o => o.title) : result
+  });
+
+  return result;
 }
 
 module.exports = { generateOpportunities };

--- a/functions/logs.json
+++ b/functions/logs.json
@@ -6,5 +6,13 @@
     "userId": "sample-user",
     "inputSummary": { "sample": true },
     "outputSummary": { "roadmap": [] }
+  },
+  {
+    "timestamp": "2023-01-01T00:00:00.000Z",
+    "agentName": "opportunity-agent",
+    "agentVersion": "1.0.0",
+    "userId": "sample-user",
+    "inputSummary": { "skills": ["coding"] },
+    "outputSummary": { "opportunities": [] }
   }
 ]


### PR DESCRIPTION
## Summary
- implement `generateOpportunities` with logger and executeAgent
- add placeholder entry for opportunity-agent in `logs.json`
- npm install so `node` require passes

## Testing
- `npm install`
- `node -e "require('./functions/agents/opportunityAgent.js')"`

------
https://chatgpt.com/codex/tasks/task_e_68648adf6f0083239850a695a4f325db