### PR TITLE
Add Firebase dashboard page

### DIFF
--- a/public/dashboard.html
+++ b/public/dashboard.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Agent Output Dashboard</title>
+  <link href="https://cdn.jsdelivr.net/npm/tailwindcss@2/dist/tailwind.min.css" rel="stylesheet">
+  <script src="https://www.gstatic.com/firebasejs/9.6.10/firebase-app-compat.js"></script>
+  <script src="https://www.gstatic.com/firebasejs/9.6.10/firebase-firestore-compat.js"></script>
+</head>
+<body class="bg-gray-100 p-6">
+  <div class="max-w-3xl mx-auto">
+    <h1 class="text-2xl font-semibold mb-4">Central Agent Dashboard</h1>
+    <div class="mb-4">
+      <input id="userIdInput" type="text" placeholder="Enter user ID" class="border p-2 w-64 mr-2">
+      <button id="fetchBtn" class="bg-blue-600 text-white px-4 py-2 rounded">Fetch</button>
+      <span id="status" class="ml-4 text-sm"></span>
+    </div>
+    <div id="roadmap" class="mb-6"></div>
+    <div id="resume" class="mb-6"></div>
+    <div id="opportunities" class="mb-6"></div>
+  </div>
+  <script src="dashboard.js"></script>
+</body>
+</html>

--- a/public/dashboard.js
+++ b/public/dashboard.js
@@ -1,0 +1,95 @@
+// Firebase configuration placeholder - replace with your Firebase project values
+const firebaseConfig = {
+  apiKey: "YOUR_API_KEY",
+  authDomain: "YOUR_PROJECT_ID.firebaseapp.com",
+  projectId: "YOUR_PROJECT_ID",
+};
+firebase.initializeApp(firebaseConfig);
+const db = firebase.firestore();
+
+const statusEl = document.getElementById('status');
+
+document.getElementById('fetchBtn').addEventListener('click', async () => {
+  const userId = document.getElementById('userIdInput').value.trim();
+  statusEl.className = 'ml-4 text-sm';
+  statusEl.textContent = '';
+  if (!userId) {
+    statusEl.textContent = 'Please enter a user ID.';
+    statusEl.classList.add('text-red-500');
+    return;
+  }
+
+  try {
+    const userRef = db.collection('users').doc(userId);
+
+    const roadmapSnap = await userRef.collection('roadmap').limit(1).get();
+    const resumeSnap = await userRef.collection('resume').limit(1).get();
+    const oppSnap = await userRef.collection('opportunities').limit(1).get();
+
+    if (!roadmapSnap.empty) {
+      renderRoadmap(roadmapSnap.docs[0].data().roadmap || []);
+    } else {
+      renderRoadmap([]);
+    }
+
+    if (!resumeSnap.empty) {
+      renderResume(resumeSnap.docs[0].data().summary || '');
+    } else {
+      renderResume('');
+    }
+
+    if (!oppSnap.empty) {
+      renderOpportunities(oppSnap.docs[0].data().opportunities || []);
+    } else {
+      renderOpportunities([]);
+    }
+
+    statusEl.textContent = 'Data loaded successfully.';
+    statusEl.classList.add('text-green-600');
+  } catch (err) {
+    console.error('Error fetching user data', err);
+    statusEl.textContent = 'Failed to fetch data.';
+    statusEl.classList.add('text-red-500');
+  }
+});
+
+function renderRoadmap(steps) {
+  const container = document.getElementById('roadmap');
+  container.innerHTML = '<h2 class="text-xl font-semibold mb-2">\uD83D\uDCCD Roadmap</h2>';
+  if (!steps.length) {
+    container.innerHTML += '<p>No roadmap found.</p>';
+    return;
+  }
+  const list = document.createElement('ul');
+  list.className = 'list-disc ml-5';
+  steps.forEach(step => {
+    const li = document.createElement('li');
+    li.textContent = `${step.phase}: ${step.description}`;
+    list.appendChild(li);
+  });
+  container.appendChild(list);
+}
+
+function renderResume(summary) {
+  const container = document.getElementById('resume');
+  container.innerHTML = '<h2 class="text-xl font-semibold mb-2">\uD83D\uDCC4 Resume</h2>';
+  container.innerHTML += summary ? `<p>${summary}</p>` : '<p>No resume summary found.</p>';
+}
+
+function renderOpportunities(list) {
+  const container = document.getElementById('opportunities');
+  container.innerHTML = '<h2 class="text-xl font-semibold mb-2">\uD83D\uDD0D Opportunities</h2>';
+  if (!list.length) {
+    container.innerHTML += '<p>No opportunities found.</p>';
+    return;
+  }
+  const ul = document.createElement('ul');
+  ul.className = 'list-disc ml-5';
+  list.forEach(op => {
+    const li = document.createElement('li');
+    const link = op.link ? `<a href="${op.link}" target="_blank" class="text-blue-600 underline">${op.title}</a>` : op.title;
+    li.innerHTML = link;
+    ul.appendChild(li);
+  });
+  container.appendChild(ul);
+}


### PR DESCRIPTION
## Summary
- add `dashboard.html` and `dashboard.js` in `public/` to view roadmap, resume and opportunities
- use Firebase web SDK and Tailwind via CDN
- allow entering a user id and fetch data from Firestore

## Testing
- `npm test` *(fails: could not read package.json)*
- `cd functions && npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68648b08e7808323a57803cb609bd26f