### PR TITLE
Add modular logging to resume-agent

### DIFF
--- a/functions/agents/resumeAgent.js
+++ b/functions/agents/resumeAgent.js
@@ -1,17 +1,54 @@
 const { executeAgent } = require('../utils/agent-wrapper');
+const { logAgentOutput } = require('../logger');
 
-async function generateResumeSummary(userData, userId) {
-  return executeAgent({
-    agentName: 'resume-agent',
-    version: 'v1.0.2',
-    userId,
-    input: userData,
-    agentFunction: async (input) => {
-      const name = input.fullName || 'User';
-      const outcome = input.dreamOutcome || 'your desired goal';
-      return `Hi, I'm ${name}. I aim to achieve ${outcome}. I bring strengths in leadership and adaptability.`;
-    }
-  });
+/**
+ * Core resume summary generation logic.
+ * This can be reused independently of the agent wrapper.
+ * @param {Object} data
+ * @returns {Promise<string>}
+ */
+async function resumeSummaryCore(data = {}) {
+  const name = data.fullName || 'User';
+  const outcome = data.dreamOutcome || 'your desired goal';
+  return `Hi, I'm ${name}. I aim to achieve ${outcome}. I bring strengths in leadership and adaptability.`;
 }
 
-module.exports = { generateResumeSummary };
+/**
+ * Generate a short resume summary for the given user.
+ *
+ * @param {Object} userData - Raw user profile information
+ * @param {string} userId - UID or email
+ * @param {Object} [metadata] - Optional agent metadata
+ * @param {string} [metadata.agentVersion] - Version string for logging
+ * @param {boolean} [metadata.useWrapper=true] - Whether to run through executeAgent
+ * @returns {Promise<string>} Resume summary output
+ */
+async function generateResumeSummary(userData = {}, userId = 'unknown', metadata = {}) {
+  const agentName = 'resume-agent';
+  const agentVersion = metadata.agentVersion || 'v1.0.3';
+  const useWrapper = metadata.useWrapper !== false; // default true
+
+  const agentFn = async (input) => resumeSummaryCore(input);
+
+  // Execute directly or via wrapper for consistency with other agents
+  const summary = useWrapper
+    ? await executeAgent({ agentName, version: agentVersion, userId, input: userData, agentFunction: agentFn })
+    : await agentFn(userData);
+
+  // Log input and output using modular logger
+  try {
+    await logAgentOutput({
+      agentName,
+      agentVersion,
+      userId,
+      inputSummary: userData,
+      outputSummary: summary
+    });
+  } catch (err) {
+    console.error('resume-agent logging failed', err);
+  }
+
+  return summary;
+}
+
+module.exports = { generateResumeSummary, resumeSummaryCore };

--- a/functions/logs.json
+++ b/functions/logs.json
@@ -4,7 +4,44 @@
     "agentName": "roadmap-agent",
     "agentVersion": "1.0.0",
     "userId": "sample-user",
-    "inputSummary": { "sample": true },
-    "outputSummary": { "roadmap": [] }
+    "inputSummary": {
+      "sample": true
+    },
+    "outputSummary": {
+      "roadmap": []
+    }
+  },
+  {
+    "timestamp": "2023-01-02T00:00:00.000Z",
+    "agentName": "resume-agent",
+    "agentVersion": "1.0.3",
+    "userId": "sample-user",
+    "inputSummary": {
+      "fullName": "Sample User"
+    },
+    "outputSummary": "Hi, I'm Sample User. I aim to achieve your desired goal. I bring strengths in leadership and adaptability."
+  },
+  {
+    "agent": "resume-agent",
+    "version": "v1.0.3",
+    "user": "test-user",
+    "status": "pass",
+    "alignment": {
+      "passed": true,
+      "flags": []
+    },
+    "timestamp": "2025-07-02T01:27:47.384Z",
+    "outputSummary": "Hi, I'm Test Runner. I aim to achieve land an amazing role. I bring strengths in leadership and adap"
+  },
+  {
+    "timestamp": "2025-07-02T01:27:47.670Z",
+    "agentName": "resume-agent",
+    "agentVersion": "v1.0.3",
+    "userId": "test-user",
+    "inputSummary": {
+      "fullName": "Test Runner",
+      "dreamOutcome": "land an amazing role"
+    },
+    "outputSummary": "Hi, I'm Test Runner. I aim to achieve land an amazing role. I bring strengths in leadership and adaptability."
   }
 ]

--- a/functions/testResumeAgent.js
+++ b/functions/testResumeAgent.js
@@ -1,0 +1,17 @@
+const admin = require('firebase-admin');
+const { generateResumeSummary } = require('./agents/resumeAgent');
+
+// Initialize Firebase app for local testing if not already initialized
+try {
+  admin.initializeApp();
+} catch (e) {
+  // ignore if already initialized or failure
+}
+
+(async () => {
+  const output = await generateResumeSummary(
+    { fullName: 'Test Runner', dreamOutcome: 'land an amazing role' },
+    'test-user'
+  );
+  console.log('Generated summary:', output);
+})();


### PR DESCRIPTION
## Summary
- implement optional executeAgent wrapper and modular logging in `resume-agent`
- add example logs showing `resume-agent` output
- provide standalone `testResumeAgent.js` to verify agent execution

## Testing
- `npm install`
- `node testResumeAgent.js`

------
https://chatgpt.com/codex/tasks/task_e_68648a9e0afc8323ba41c6c8198f0163