### PR TITLE
Add agent run retries and tracking

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -45,3 +45,5 @@ exports.getLogs = functions.https.onRequest(async (req, res) => {
     res.status(500).json({ error: 'Internal error' });
   }
 });
+
+exports.retryAgentRun = require('./retryAgentRun').retryAgentRun;

--- a/functions/retryAgentRun.js
+++ b/functions/retryAgentRun.js
@@ -1,0 +1,96 @@
+const admin = require('firebase-admin');
+const functions = require('firebase-functions');
+const { generateRoadmap } = require('./agents/roadmapAgent');
+const { generateResumeSummary } = require('./agents/resumeAgent');
+const { generateOpportunities } = require('./agents/opportunityAgent');
+
+const agentMap = {
+  'roadmap-agent': generateRoadmap,
+  'resume-agent': generateResumeSummary,
+  'opportunity-agent': generateOpportunities
+};
+
+async function retryRun(userId, agentName) {
+  const db = admin.firestore();
+  const snap = await db
+    .collection('users')
+    .doc(userId)
+    .collection('agentRuns')
+    .where('agentName', '==', agentName)
+    .where('status', '==', 'error')
+    .orderBy('timestamp', 'desc')
+    .limit(1)
+    .get();
+
+  if (snap.empty) {
+    throw new Error('No failed run found');
+  }
+
+  const doc = snap.docs[0];
+  const data = doc.data();
+  const input = data.input || {};
+
+  if (!agentMap[agentName]) throw new Error('Unknown agent');
+
+  const output = await agentMap[agentName](input, userId);
+
+  await doc.ref.update({
+    output,
+    status: 'success',
+    resolved: true,
+    timestamp: new Date().toISOString()
+  });
+
+  if (process.env.RETRY_WEBHOOK) {
+    try {
+      await fetch(process.env.RETRY_WEBHOOK, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ text: `Resolved ${agentName} for ${userId}` })
+      });
+    } catch (err) {
+      console.error('webhook failed', err);
+    }
+  }
+
+  return output;
+}
+
+exports.retryAgentRun = functions.https.onRequest(async (req, res) => {
+  res.set('Access-Control-Allow-Origin', '*');
+  res.set('Access-Control-Allow-Headers', 'Content-Type, Authorization');
+  if (req.method === 'OPTIONS') {
+    res.status(204).send('');
+    return;
+  }
+
+  const authHeader = req.headers.authorization || '';
+  const match = authHeader.match(/^Bearer (.+)$/);
+  if (!match) {
+    res.status(401).json({ error: 'Unauthorized' });
+    return;
+  }
+
+  try {
+    const decoded = await admin.auth().verifyIdToken(match[1]);
+    const allowed = (functions.config().debug && functions.config().debug.allowlist)
+      ? functions.config().debug.allowlist.split(',')
+      : ['admin@example.com'];
+    if (!decoded.email || !allowed.includes(decoded.email)) {
+      res.status(403).json({ error: 'Forbidden' });
+      return;
+    }
+
+    const { userId = decoded.uid, agentName } = req.body || {};
+    if (!userId || !agentName) {
+      res.status(400).json({ error: 'Missing parameters' });
+      return;
+    }
+
+    const output = await retryRun(userId, agentName);
+    res.json({ status: 'success', output });
+  } catch (err) {
+    console.error('retryAgentRun error', err);
+    res.status(500).json({ error: err.message });
+  }
+});

--- a/public/debug.html
+++ b/public/debug.html
@@ -24,12 +24,15 @@
         Filter:
         <select id="statusFilter" class="border p-1">
           <option value="">All</option>
-          <option value="pass">Success</option>
-          <option value="fail">Errors</option>
+          <option value="success">Success</option>
+          <option value="error">Errors</option>
         </select>
       </label>
       <label class="ml-4">
         <input type="checkbox" id="liveReload" class="mr-1">Live reload
+      </label>
+      <label class="ml-4">
+        <input type="checkbox" id="rerunFailed" class="mr-1">Re-run Failed Agents
       </label>
       <button id="refreshBtn" class="ml-4 bg-gray-200 px-2 py-1 rounded">Refresh</button>
       <button id="logoutBtn" class="ml-4 bg-red-500 text-white px-2 py-1 rounded">Logout</button>


### PR DESCRIPTION
## Summary
- track agent execution in `/users/{user}/agentRuns`
- create cloud function `retryAgentRun` to repeat failed runs
- update agent wrapper to log success/error and status
- expose retry toggle in `debug.html` and implement retry logic in `debug.js`
- export retry function in index

## Testing
- `npm install --prefix functions`
- `npm test --prefix functions` *(fails to write to Firestore due to missing project ID)*

------
https://chatgpt.com/codex/tasks/task_e_686492d18a948323900e407886340cc6