### PR TITLE
Implement insights agent with frontend dashboard hooks

### DIFF
--- a/frontend/dashboard.html
+++ b/frontend/dashboard.html
@@ -13,8 +13,16 @@
   <div class="container">
     <h1>Opportunity Dashboard</h1>
     <div id="roadmap" class="roadmap"></div>
+    <button onclick="toggleInsights('roadmap-agent')" class="insights-btn">View Insights</button>
+    <div id="roadmap-agentInsights" class="insights hidden"></div>
+
     <div id="resume" class="resume"></div>
+    <button onclick="toggleInsights('resume-agent')" class="insights-btn">View Insights</button>
+    <div id="resume-agentInsights" class="insights hidden"></div>
+
     <div id="opportunities" class="opportunities"></div>
+    <button onclick="toggleInsights('opportunity-agent')" class="insights-btn">View Insights</button>
+    <div id="opportunity-agentInsights" class="insights hidden"></div>
   </div>
   <script src="dashboard.js"></script>
 </body>

--- a/frontend/dashboard.js
+++ b/frontend/dashboard.js
@@ -45,6 +45,41 @@ function renderOpportunities(list = []) {
   container.appendChild(grid);
 }
 
+function renderInsights(agent, data) {
+  const container = document.getElementById(`${agent}Insights`);
+  container.innerHTML = '';
+  if (!data) {
+    container.textContent = 'No insights available';
+    return;
+  }
+  const wrapper = document.createElement('div');
+  Object.keys(data).forEach(key => {
+    const card = document.createElement('div');
+    card.className = 'metric-card';
+    card.innerHTML = `<strong>${key}</strong><div>${data[key]}</div>`;
+    wrapper.appendChild(card);
+  });
+  if (data.failureRate && data.failureRate > 0.25) {
+    const alert = document.createElement('div');
+    alert.className = 'alert';
+    alert.textContent = '⚠️ High failure rate';
+    wrapper.appendChild(alert);
+  }
+  container.appendChild(wrapper);
+}
+
+function toggleInsights(agent) {
+  const container = document.getElementById(`${agent}Insights`);
+  container.classList.toggle('hidden');
+  if (!container.dataset.loaded) {
+    const userId = getUserId();
+    db.collection('users').doc(userId).collection('insights').doc(agent).get().then(doc => {
+      renderInsights(agent, doc.exists ? doc.data() : null);
+      container.dataset.loaded = 'true';
+    });
+  }
+}
+
 function initDashboard() {
   const userId = getUserId();
   if (!userId) return alert('No user ID provided');

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -44,3 +44,23 @@ body {
   margin-top: 10px;
   color: #0366d6;
 }
+
+.insights {
+  background: #fff;
+  border: 1px solid #ddd;
+  padding: 10px;
+  margin-bottom: 20px;
+}
+
+.metric-card {
+  display: inline-block;
+  padding: 5px 10px;
+  margin: 4px;
+  background: #f9f9f9;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+}
+
+.hidden { display: none; }
+
+.alert { color: #b91c1c; font-weight: bold; }

--- a/functions/agents/insightsAgent.js
+++ b/functions/agents/insightsAgent.js
@@ -1,0 +1,166 @@
+const admin = require('firebase-admin');
+const functions = require('firebase-functions');
+const fs = require('fs');
+const path = require('path');
+
+function aggregateRuns(runs = []) {
+  const metrics = {};
+  runs.forEach(r => {
+    const name = r.agentName || r.agent;
+    if (!name) return;
+    if (!metrics[name]) {
+      metrics[name] = {
+        executionCount: 0,
+        success: 0,
+        failure: 0,
+        totalInputSize: 0,
+        totalOutputSize: 0,
+        errors: {},
+        totalOpportunities: 0,
+        roadmapSteps: 0,
+        resumeValue: 0,
+        lastExecution: ''
+      };
+    }
+    const m = metrics[name];
+    m.executionCount += 1;
+    if (r.status === 'success' || r.resolved) m.success += 1; else m.failure += 1;
+    const inputSize = JSON.stringify(r.input || {}).length;
+    const outputSize = JSON.stringify(r.output || {}).length;
+    m.totalInputSize += inputSize;
+    m.totalOutputSize += outputSize;
+    const ts = r.timestamp || r.time;
+    if (ts && (!m.lastExecution || ts > m.lastExecution)) m.lastExecution = ts;
+    if (r.error) {
+      const key = String(r.error).slice(0, 50);
+      m.errors[key] = (m.errors[key] || 0) + 1;
+    }
+    if (name === 'opportunity-agent' && Array.isArray(r.output)) {
+      m.totalOpportunities += r.output.length;
+    }
+    if (name === 'roadmap-agent' && Array.isArray(r.output)) {
+      m.roadmapSteps += r.output.length;
+    }
+    if (name === 'resume-agent' && typeof r.output === 'string') {
+      m.resumeValue += r.output.length;
+    }
+  });
+
+  const result = {};
+  Object.keys(metrics).forEach(name => {
+    const d = metrics[name];
+    result[name] = {
+      executionCount: d.executionCount,
+      successRate: d.executionCount ? d.success / d.executionCount : 0,
+      failureRate: d.executionCount ? d.failure / d.executionCount : 0,
+      avgInputSize: d.executionCount ? d.totalInputSize / d.executionCount : 0,
+      avgOutputSize: d.executionCount ? d.totalOutputSize / d.executionCount : 0,
+      mostCommonErrors: Object.entries(d.errors)
+        .sort((a, b) => b[1] - a[1])
+        .slice(0, 3)
+        .map(e => e[0]),
+      totalOpportunities: d.totalOpportunities,
+      roadmapSteps: d.roadmapSteps,
+      estimatedResumeValueUplift: d.executionCount ? d.resumeValue / d.executionCount : 0,
+      lastExecution: d.lastExecution
+    };
+  });
+  return result;
+}
+
+function loadLocalRuns() {
+  const logPath = path.join(__dirname, '..', 'logs.json');
+  try {
+    const raw = fs.readFileSync(logPath, 'utf8');
+    const data = JSON.parse(raw);
+    return Array.isArray(data) ? data : [];
+  } catch (_) {
+    return [];
+  }
+}
+
+async function computeUserInsights(userId) {
+  const db = admin.firestore();
+  let runs = [];
+  try {
+    const snap = await db.collection('users').doc(userId).collection('agentRuns').get();
+    runs = snap.docs.map(d => d.data());
+  } catch (err) {
+    console.error('user insight firestore failed', err.message);
+  }
+  if (!runs.length) {
+    runs = loadLocalRuns().filter(r => r.userId === userId || r.user === userId);
+  }
+  const metrics = aggregateRuns(runs);
+  for (const [agentName, data] of Object.entries(metrics)) {
+    await db.collection('users').doc(userId).collection('insights').doc(agentName).set(data, { merge: true });
+  }
+  return metrics;
+}
+
+async function computeGlobalInsights() {
+  const db = admin.firestore();
+  let runs = [];
+  try {
+    const snap = await db.collectionGroup('agentRuns').get();
+    runs = snap.docs.map(d => d.data());
+  } catch (err) {
+    console.error('global insight firestore failed', err.message);
+  }
+  if (!runs.length) runs = loadLocalRuns();
+  const metrics = aggregateRuns(runs);
+  for (const [agentName, data] of Object.entries(metrics)) {
+    await db.collection('global').doc('insights').collection('agents').doc(agentName).set(data, { merge: true });
+  }
+  return metrics;
+}
+
+exports.runAllInsights = async () => {
+  const db = admin.firestore();
+  const users = await db.collection('users').get();
+  for (const doc of users.docs) {
+    await computeUserInsights(doc.id);
+  }
+  return computeGlobalInsights();
+};
+
+exports.updateInsightsCron = functions.pubsub.schedule('every 24 hours').onRun(async () => {
+  await exports.runAllInsights();
+});
+
+exports.getInsights = functions.https.onRequest(async (req, res) => {
+  res.set('Access-Control-Allow-Origin', '*');
+  res.set('Access-Control-Allow-Headers', 'Content-Type, Authorization');
+  if (req.method === 'OPTIONS') {
+    res.status(204).send('');
+    return;
+  }
+
+  const authHeader = req.headers.authorization || '';
+  const match = authHeader.match(/^Bearer (.+)$/);
+  if (!match) {
+    res.status(401).json({ error: 'Unauthorized' });
+    return;
+  }
+
+  try {
+    const decoded = await admin.auth().verifyIdToken(match[1]);
+    const allowed = (functions.config().debug && functions.config().debug.allowlist)
+      ? functions.config().debug.allowlist.split(',')
+      : ['admin@example.com'];
+    if (!decoded.email || !allowed.includes(decoded.email)) {
+      res.status(403).json({ error: 'Forbidden' });
+      return;
+    }
+    const userId = req.query.userId;
+    let data;
+    if (userId) data = await computeUserInsights(userId);
+    else data = await computeGlobalInsights();
+    res.json(data);
+  } catch (err) {
+    console.error('getInsights error', err);
+    res.status(500).json({ error: err.message });
+  }
+});
+
+module.exports = { aggregateRuns, computeUserInsights, computeGlobalInsights };

--- a/functions/index.js
+++ b/functions/index.js
@@ -47,3 +47,6 @@ exports.getLogs = functions.https.onRequest(async (req, res) => {
 });
 
 exports.retryAgentRun = require('./retryAgentRun').retryAgentRun;
+const insights = require('./agents/insightsAgent');
+exports.updateInsightsCron = insights.updateInsightsCron;
+exports.getInsights = insights.getInsights;

--- a/functions/package.json
+++ b/functions/package.json
@@ -9,6 +9,6 @@
     "firebase-functions": "^3.20.1"
   },
   "scripts": {
-    "test": "node testRoadmapAgent.js && node testResumeAgent.js && node testOpportunityAgent.js && node testOnboardingFlow.js"
+    "test": "node testRoadmapAgent.js && node testResumeAgent.js && node testOpportunityAgent.js && node testOnboardingFlow.js && node testInsightsAgent.js"
   }
 }

--- a/functions/testInsightsAgent.js
+++ b/functions/testInsightsAgent.js
@@ -1,0 +1,11 @@
+const { aggregateRuns } = require('./agents/insightsAgent');
+const fs = require('fs');
+const path = require('path');
+
+(async () => {
+  const logPath = path.join(__dirname, 'logs.json');
+  const raw = fs.readFileSync(logPath, 'utf8');
+  const data = JSON.parse(raw);
+  const metrics = aggregateRuns(data);
+  console.log('Insights metrics:', JSON.stringify(metrics, null, 2));
+})();

--- a/public/debug-insights.html
+++ b/public/debug-insights.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Insights Console</title>
+  <link href="https://cdn.jsdelivr.net/npm/tailwindcss@2/dist/tailwind.min.css" rel="stylesheet">
+  <script src="https://www.gstatic.com/firebasejs/9.6.10/firebase-app-compat.js"></script>
+  <script src="https://www.gstatic.com/firebasejs/9.6.10/firebase-auth-compat.js"></script>
+</head>
+<body class="bg-gray-100 p-4">
+  <div class="max-w-5xl mx-auto">
+    <h1 class="text-2xl font-bold mb-4">Insights Console</h1>
+
+    <div id="loginSection" class="mb-4">
+      <input id="email" class="border p-2 mr-2" placeholder="Email">
+      <input id="password" type="password" class="border p-2 mr-2" placeholder="Password">
+      <button id="loginBtn" class="bg-blue-600 text-white px-4 py-2 rounded">Login</button>
+      <p id="loginStatus" class="text-sm mt-2"></p>
+    </div>
+
+    <div id="controls" class="hidden mb-4">
+      <button id="refreshBtn" class="bg-gray-200 px-2 py-1 rounded">Refresh</button>
+      <button id="logoutBtn" class="ml-4 bg-red-500 text-white px-2 py-1 rounded">Logout</button>
+    </div>
+
+    <div id="insightsContainer"></div>
+  </div>
+  <script src="debug-insights.js"></script>
+</body>
+</html>

--- a/public/debug-insights.js
+++ b/public/debug-insights.js
@@ -1,0 +1,75 @@
+// Firebase config placeholder
+const firebaseConfig = {
+  apiKey: "YOUR_API_KEY",
+  authDomain: "YOUR_PROJECT_ID.firebaseapp.com",
+  projectId: "YOUR_PROJECT_ID"
+};
+firebase.initializeApp(firebaseConfig);
+const auth = firebase.auth();
+
+const allowedEmails = ["admin@example.com"];
+
+async function fetchInsights() {
+  const user = auth.currentUser;
+  if (!user) return;
+  try {
+    const token = await user.getIdToken();
+    const url = `https://us-central1-${firebaseConfig.projectId}.cloudfunctions.net/getInsights`;
+    const res = await fetch(url, { headers: { Authorization: `Bearer ${token}` } });
+    const data = await res.json();
+    renderInsights(data);
+  } catch (err) {
+    console.error('Failed to load insights', err);
+  }
+}
+
+function renderInsights(data) {
+  const container = document.getElementById('insightsContainer');
+  container.innerHTML = '';
+  Object.keys(data).forEach(agent => {
+    const section = document.createElement('div');
+    section.className = 'mb-6';
+    section.innerHTML = `<h2 class="text-xl font-semibold mb-2">${agent}</h2>`;
+    const pre = document.createElement('pre');
+    pre.textContent = JSON.stringify(data[agent], null, 2);
+    section.appendChild(pre);
+    container.appendChild(section);
+  });
+}
+
+document.getElementById('loginBtn').addEventListener('click', async () => {
+  const email = document.getElementById('email').value.trim();
+  const password = document.getElementById('password').value;
+  const statusEl = document.getElementById('loginStatus');
+  statusEl.textContent = '';
+  try {
+    const cred = await auth.signInWithEmailAndPassword(email, password);
+    if (!allowedEmails.includes(cred.user.email)) {
+      statusEl.textContent = 'Unauthorized';
+      await auth.signOut();
+      return;
+    }
+    document.getElementById('loginSection').classList.add('hidden');
+    document.getElementById('controls').classList.remove('hidden');
+    fetchInsights();
+  } catch (err) {
+    console.error('login failed', err);
+    statusEl.textContent = err.message;
+  }
+});
+
+document.getElementById('logoutBtn').addEventListener('click', async () => {
+  await auth.signOut();
+  document.getElementById('controls').classList.add('hidden');
+  document.getElementById('loginSection').classList.remove('hidden');
+});
+
+document.getElementById('refreshBtn').addEventListener('click', fetchInsights);
+
+auth.onAuthStateChanged(user => {
+  if (user && allowedEmails.includes(user.email)) {
+    document.getElementById('loginSection').classList.add('hidden');
+    document.getElementById('controls').classList.remove('hidden');
+    fetchInsights();
+  }
+});


### PR DESCRIPTION
## Summary
- add an insights agent to aggregate `agentRuns` history
- export cron and API endpoints for insight metrics
- integrate dashboard with metrics toggle
- provide developer console for insights
- add unit test for aggregation logic

## Testing
- `npm install`
- `npm test` *(fails: Unable to detect a Project Id)*

------
https://chatgpt.com/codex/tasks/task_e_6864942a7e848323b03e6ed7c914915a