### PR TITLE
Add trends agent with tips UI

### DIFF
--- a/functions/agents/trendsAgent.js
+++ b/functions/agents/trendsAgent.js
@@ -1,0 +1,133 @@
+const admin = require('firebase-admin');
+const functions = require('firebase-functions');
+
+function aggregateUsage(runs = []) {
+  const byAgent = {};
+  runs.forEach(r => {
+    const name = r.agentName || r.agent;
+    if (!name) return;
+    const ts = new Date(r.timestamp || r.time || Date.now());
+    const dow = ts.getDay();
+    const dayKey = ts.toISOString().slice(0,10);
+    const weekKey = `${ts.getFullYear()}-W${getWeekNumber(ts)}`;
+    if (!byAgent[name]) {
+      byAgent[name] = { daily: {}, weekly: {}, total: 0, success: 0, failure: 0, dow: Array(7).fill(0), failDow: Array(7).fill(0) };
+    }
+    const m = byAgent[name];
+    m.daily[dayKey] = (m.daily[dayKey] || 0) + 1;
+    m.weekly[weekKey] = (m.weekly[weekKey] || 0) + 1;
+    m.total += 1;
+    m.dow[dow] += 1;
+    if (r.status === 'success' || r.resolved) m.success += 1; else { m.failure += 1; m.failDow[dow] += 1; }
+  });
+  const result = {};
+  Object.keys(byAgent).forEach(agent => {
+    const d = byAgent[agent];
+    const worstDow = d.failDow.indexOf(Math.max(...d.failDow));
+    const busyDow = d.dow.indexOf(Math.max(...d.dow));
+    result[agent] = {
+      daily: d.daily,
+      weekly: d.weekly,
+      totalRuns: d.total,
+      successRate: d.total ? d.success / d.total : 0,
+      busyDayOfWeek: busyDow,
+      failureProneDay: worstDow
+    };
+  });
+  return result;
+}
+
+function getWeekNumber(date) {
+  const tmp = new Date(Date.UTC(date.getFullYear(), date.getMonth(), date.getDate()));
+  const dayNum = tmp.getUTCDay() || 7;
+  tmp.setUTCDate(tmp.getUTCDate() + 4 - dayNum);
+  const yearStart = new Date(Date.UTC(tmp.getUTCFullYear(),0,1));
+  return Math.ceil((((tmp - yearStart) / 86400000) + 1)/7);
+}
+
+async function computeUserTrends(userId) {
+  const db = admin.firestore();
+  const snap = await db.collection('users').doc(userId).collection('agentRuns').get();
+  const runs = snap.docs.map(d => d.data());
+  const metrics = aggregateUsage(runs);
+  const suggestions = [];
+  const forecast = {};
+  const now = Date.now();
+  for (const agent of ['roadmap-agent','resume-agent','opportunity-agent']) {
+    const list = runs.filter(r => (r.agentName || r.agent) === agent).sort((a,b)=>new Date(b.timestamp)-new Date(a.timestamp));
+    if (!list.length) {
+      suggestions.push(`You have not run ${agent} yet.`);
+      continue;
+    }
+    const last = list[0];
+    const nextTime = new Date(new Date(last.timestamp).getTime() + 24*60*60*1000).toISOString();
+    forecast[agent] = nextTime;
+    if (now - new Date(last.timestamp).getTime() > 7*24*60*60*1000) {
+      suggestions.push(`Run ${agent} again to keep data fresh.`);
+    }
+  }
+  const data = { metrics, forecast, suggestions };
+  await db.collection('users').doc(userId).collection('trends').doc('summary').set(data, { merge: true });
+  return data;
+}
+
+async function computeGlobalTrends() {
+  const db = admin.firestore();
+  const snap = await db.collectionGroup('agentRuns').get();
+  const runs = snap.docs.map(d => d.data());
+  const metrics = aggregateUsage(runs);
+  const data = { metrics, generated: new Date().toISOString() };
+  await db.collection('globalTrends').doc('forecast').set(data, { merge: true });
+  return data;
+}
+
+exports.runAllTrends = async () => {
+  const db = admin.firestore();
+  const users = await db.collection('users').get();
+  for (const doc of users.docs) {
+    await computeUserTrends(doc.id);
+  }
+  return computeGlobalTrends();
+};
+
+exports.updateTrendsCron = functions.pubsub.schedule('every 24 hours').onRun(async () => {
+  await exports.runAllTrends();
+});
+
+exports.getTrends = functions.https.onRequest(async (req, res) => {
+  res.set('Access-Control-Allow-Origin', '*');
+  res.set('Access-Control-Allow-Headers', 'Content-Type, Authorization');
+  if (req.method === 'OPTIONS') {
+    res.status(204).send('');
+    return;
+  }
+
+  const authHeader = req.headers.authorization || '';
+  const match = authHeader.match(/^Bearer (.+)$/);
+  if (!match) {
+    res.status(401).json({ error: 'Unauthorized' });
+    return;
+  }
+
+  try {
+    const decoded = await admin.auth().verifyIdToken(match[1]);
+    const allowed = (functions.config().debug && functions.config().debug.allowlist)
+      ? functions.config().debug.allowlist.split(',')
+      : ['admin@example.com'];
+    if (!decoded.email || !allowed.includes(decoded.email)) {
+      res.status(403).json({ error: 'Forbidden' });
+      return;
+    }
+    const userId = req.query.userId;
+    let data;
+    if (userId) data = await computeUserTrends(userId);
+    else data = await computeGlobalTrends();
+    res.json(data);
+  } catch (err) {
+    console.error('getTrends error', err);
+    res.status(500).json({ error: err.message });
+  }
+});
+
+module.exports = { aggregateUsage, computeUserTrends, computeGlobalTrends };
+

--- a/functions/index.js
+++ b/functions/index.js
@@ -53,3 +53,8 @@ exports.getInsights = insights.getInsights;
 
 const anomalies = require('./agents/anomalyAgent');
 exports.anomalyCron = anomalies.anomalyCron;
+
+const trends = require('./agents/trendsAgent');
+exports.updateTrendsCron = trends.updateTrendsCron;
+exports.getTrends = trends.getTrends;
+

--- a/functions/package.json
+++ b/functions/package.json
@@ -9,6 +9,6 @@
     "firebase-functions": "^3.20.1"
   },
   "scripts": {
-    "test": "node testRoadmapAgent.js && node testResumeAgent.js && node testOpportunityAgent.js && node testOnboardingFlow.js && node testInsightsAgent.js && node testAnomalyAgent.js"
+    "test": "node testRoadmapAgent.js && node testResumeAgent.js && node testOpportunityAgent.js && node testOnboardingFlow.js && node testInsightsAgent.js && node testAnomalyAgent.js && node testTrendsAgent.js"
   }
 }

--- a/functions/testTrendsAgent.js
+++ b/functions/testTrendsAgent.js
@@ -1,0 +1,14 @@
+const admin = require('firebase-admin');
+const { computeGlobalTrends } = require('./agents/trendsAgent');
+
+try {
+  admin.initializeApp();
+} catch (e) {
+  // ignore if already initialized
+}
+
+(async () => {
+  const trends = await computeGlobalTrends();
+  console.log('Trends:', JSON.stringify(trends, null, 2));
+})();
+

--- a/public/dashboard.html
+++ b/public/dashboard.html
@@ -20,6 +20,10 @@
     <div id="roadmap" class="mb-6"></div>
     <div id="resume" class="mb-6"></div>
     <div id="opportunities" class="mb-6"></div>
+    <div id="tips" class="mb-6">
+      <button id="toggleTips" class="bg-gray-200 px-2 py-1 rounded mb-2">Show Tips</button>
+      <div id="tipsContent" class="hidden"></div>
+    </div>
   </div>
   <script src="dashboard.js"></script>
 </body>

--- a/public/dashboard.js
+++ b/public/dashboard.js
@@ -26,6 +26,7 @@ document.getElementById('fetchBtn').addEventListener('click', async () => {
     const roadmapSnap = await userRef.collection('roadmap').limit(1).get();
     const resumeSnap = await userRef.collection('resume').limit(1).get();
     const oppSnap = await userRef.collection('opportunities').limit(1).get();
+    const trendSnap = await userRef.collection('trends').doc('summary').get();
     const runSnap = await userRef.collection('agentRuns').orderBy('timestamp', 'desc').limit(1).get();
 
     if (!roadmapSnap.empty) {
@@ -44,6 +45,12 @@ document.getElementById('fetchBtn').addEventListener('click', async () => {
       renderOpportunities(oppSnap.docs[0].data().opportunities || []);
     } else {
       renderOpportunities([]);
+    }
+
+    if (trendSnap.exists) {
+      renderTips(trendSnap.data());
+    } else {
+      renderTips(null);
     }
 
     if (!runSnap.empty) {
@@ -106,3 +113,26 @@ function renderOpportunities(list) {
   });
   container.appendChild(ul);
 }
+
+function renderTips(data) {
+  const container = document.getElementById('tipsContent');
+  container.innerHTML = '';
+  if (!data || !Array.isArray(data.suggestions)) {
+    container.innerHTML = '<p>No tips available.</p>';
+    return;
+  }
+  const ul = document.createElement('ul');
+  ul.className = 'list-disc ml-5';
+  data.suggestions.forEach(tip => {
+    const li = document.createElement('li');
+    li.textContent = tip;
+    ul.appendChild(li);
+  });
+  container.appendChild(ul);
+}
+
+document.getElementById('toggleTips').addEventListener('click', () => {
+  const content = document.getElementById('tipsContent');
+  content.classList.toggle('hidden');
+});
+

--- a/public/debug-trends.html
+++ b/public/debug-trends.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Trends Console</title>
+  <link href="https://cdn.jsdelivr.net/npm/tailwindcss@2/dist/tailwind.min.css" rel="stylesheet">
+  <script src="https://www.gstatic.com/firebasejs/9.6.10/firebase-app-compat.js"></script>
+  <script src="https://www.gstatic.com/firebasejs/9.6.10/firebase-auth-compat.js"></script>
+  <script src="https://www.gstatic.com/firebasejs/9.6.10/firebase-firestore-compat.js"></script>
+</head>
+<body class="bg-gray-100 p-4">
+  <div class="max-w-5xl mx-auto">
+    <h1 class="text-2xl font-bold mb-4">Trends Console</h1>
+    <div class="mb-2">
+      <a href="debug.html" class="text-blue-600 underline mr-4">Logs</a>
+      <a href="debug-anomalies.html" class="text-blue-600 underline mr-4">Anomalies</a>
+      <a href="debug-insights.html" class="text-blue-600 underline mr-4">Insights</a>
+    </div>
+
+    <div id="loginSection" class="mb-4">
+      <input id="email" class="border p-2 mr-2" placeholder="Email">
+      <input id="password" type="password" class="border p-2 mr-2" placeholder="Password">
+      <button id="loginBtn" class="bg-blue-600 text-white px-4 py-2 rounded">Login</button>
+      <p id="loginStatus" class="text-sm mt-2"></p>
+    </div>
+
+    <div id="controls" class="hidden mb-4">
+      <button id="refreshBtn" class="bg-gray-200 px-2 py-1 rounded">Refresh</button>
+      <button id="logoutBtn" class="ml-4 bg-red-500 text-white px-2 py-1 rounded">Logout</button>
+    </div>
+
+    <div id="trendsContainer"></div>
+  </div>
+  <script src="debug-trends.js"></script>
+</body>
+</html>
+

--- a/public/debug-trends.js
+++ b/public/debug-trends.js
@@ -1,0 +1,72 @@
+// Firebase config placeholder
+const firebaseConfig = {
+  apiKey: "YOUR_API_KEY",
+  authDomain: "YOUR_PROJECT_ID.firebaseapp.com",
+  projectId: "YOUR_PROJECT_ID"
+};
+firebase.initializeApp(firebaseConfig);
+const auth = firebase.auth();
+const db = firebase.firestore();
+
+const allowedEmails = ["admin@example.com"];
+
+async function fetchTrends() {
+  const snap = await db.collection('globalTrends').doc('forecast').get();
+  renderTrends(snap.exists ? snap.data() : {});
+}
+
+function renderTrends(data) {
+  const container = document.getElementById('trendsContainer');
+  container.innerHTML = '';
+  if (!data.metrics) {
+    container.textContent = 'No trend data available';
+    return;
+  }
+  Object.keys(data.metrics).forEach(agent => {
+    const section = document.createElement('div');
+    section.className = 'mb-6';
+    section.innerHTML = `<h2 class="text-xl font-semibold mb-2">${agent}</h2>`;
+    const pre = document.createElement('pre');
+    pre.textContent = JSON.stringify(data.metrics[agent], null, 2);
+    section.appendChild(pre);
+    container.appendChild(section);
+  });
+}
+
+document.getElementById('loginBtn').addEventListener('click', async () => {
+  const email = document.getElementById('email').value.trim();
+  const password = document.getElementById('password').value;
+  const statusEl = document.getElementById('loginStatus');
+  statusEl.textContent = '';
+  try {
+    const cred = await auth.signInWithEmailAndPassword(email, password);
+    if (!allowedEmails.includes(cred.user.email)) {
+      statusEl.textContent = 'Unauthorized';
+      await auth.signOut();
+      return;
+    }
+    document.getElementById('loginSection').classList.add('hidden');
+    document.getElementById('controls').classList.remove('hidden');
+    fetchTrends();
+  } catch (err) {
+    console.error('login failed', err);
+    statusEl.textContent = err.message;
+  }
+});
+
+document.getElementById('logoutBtn').addEventListener('click', async () => {
+  await auth.signOut();
+  document.getElementById('controls').classList.add('hidden');
+  document.getElementById('loginSection').classList.remove('hidden');
+});
+
+document.getElementById('refreshBtn').addEventListener('click', fetchTrends);
+
+auth.onAuthStateChanged(user => {
+  if (user && allowedEmails.includes(user.email)) {
+    document.getElementById('loginSection').classList.add('hidden');
+    document.getElementById('controls').classList.remove('hidden');
+    fetchTrends();
+  }
+});
+


### PR DESCRIPTION
## Summary
- implement new `trendsAgent` for forecasting and recommendations
- expose getTrends and cron function
- provide test runner for trends agent
- add debug page for trends output
- update dashboard with Tips section driven by trends data

## Testing
- `npm ci --prefix functions`
- `npm test --prefix functions` *(fails: Unable to detect a Project Id)*

------
https://chatgpt.com/codex/tasks/task_e_686497031c4c8323840a3585b3040b64