### PR TITLE
Add AgentHub console and registry

### DIFF
--- a/.github/workflows/registry-sync.yml
+++ b/.github/workflows/registry-sync.yml
@@ -1,0 +1,31 @@
+name: Sync Agent Registry
+
+on:
+  push:
+    paths:
+      - 'functions/agents/**'
+      - 'config/agents.json'
+
+jobs:
+  update-registry:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Setup Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18
+      - name: Run registry update
+        run: node functions/registry/updateAgentRegistry.js
+      - name: Commit registry
+        run: |
+          git config user.name github-actions
+          git config user.email actions@github.com
+          git add config/agents.json
+          git add public/config/agents.json
+          if git diff --cached --quiet; then
+            echo "No changes to commit"
+          else
+            git commit -m "chore: update agent registry"
+            git push
+          fi

--- a/README.md
+++ b/README.md
@@ -84,6 +84,13 @@ allowlist defined by `functions.config().debug.allowlist`. It fetches
 log entries from the `getLogs` Cloud Function and presents them in a
 filterable, auto-refreshing table grouped by agent.
 
+### AgentHub Console
+
+`/agent-hub.html` offers a registry-driven view of all agents with links
+to their docs and actions to re-run them. The registry is stored in
+`config/agents.json` and mirrored under `public/config/agents.json` for
+hosting.
+
 ---
 
 ## 🙌 Contributing

--- a/config/agents.json
+++ b/config/agents.json
@@ -1,0 +1,86 @@
+{
+  "roadmap-agent": {
+    "name": "roadmap-agent",
+    "description": "Generates personalized milestone plans for users",
+    "version": "v1.0.2",
+    "lastRunStatus": "unknown",
+    "agentType": "utility",
+    "enabled": true,
+    "docsUrl": "../functions/agents/roadmapAgent.js",
+    "sourcePath": "functions/agents/roadmapAgent.js",
+    "updatedAt": "2025-07-02T02:27:43.913Z",
+    "createdAt": "2025-07-02T02:27:43.913Z"
+  },
+  "resume-agent": {
+    "name": "resume-agent",
+    "description": "Creates short resume or LinkedIn summaries",
+    "version": "v1.0.3",
+    "lastRunStatus": "unknown",
+    "agentType": "utility",
+    "enabled": true,
+    "docsUrl": "../functions/agents/resumeAgent.js",
+    "sourcePath": "functions/agents/resumeAgent.js",
+    "updatedAt": "2025-07-02T02:27:43.913Z",
+    "createdAt": "2025-07-02T02:27:43.913Z"
+  },
+  "opportunity-agent": {
+    "name": "opportunity-agent",
+    "description": "Matches grants, internships and jobs",
+    "version": "v1.0.3",
+    "lastRunStatus": "unknown",
+    "agentType": "utility",
+    "enabled": true,
+    "docsUrl": "../functions/agents/opportunityAgent.js",
+    "sourcePath": "functions/agents/opportunityAgent.js",
+    "updatedAt": "2025-07-02T02:27:43.913Z",
+    "createdAt": "2025-07-02T02:27:43.913Z"
+  },
+  "anomaly-agent": {
+    "name": "anomaly-agent",
+    "description": "Detects unusual behavior across user runs",
+    "version": "v1.0.0",
+    "lastRunStatus": "unknown",
+    "agentType": "monitor",
+    "enabled": true,
+    "docsUrl": "../functions/agents/anomalyAgent.js",
+    "sourcePath": "functions/agents/anomalyAgent.js",
+    "updatedAt": "2025-07-02T02:27:43.913Z",
+    "createdAt": "2025-07-02T02:27:43.913Z"
+  },
+  "insights-agent": {
+    "name": "insights-agent",
+    "description": "Aggregates agent analytics and metrics",
+    "version": "v1.0.0",
+    "lastRunStatus": "unknown",
+    "agentType": "analytics",
+    "enabled": true,
+    "docsUrl": "../functions/agents/insightsAgent.js",
+    "sourcePath": "functions/agents/insightsAgent.js",
+    "updatedAt": "2025-07-02T02:27:43.913Z",
+    "createdAt": "2025-07-02T02:27:43.913Z"
+  },
+  "trends-agent": {
+    "name": "trends-agent",
+    "description": "Computes usage trends across all agents",
+    "version": "v1.0.0",
+    "lastRunStatus": "unknown",
+    "agentType": "analytics",
+    "enabled": true,
+    "docsUrl": "../functions/agents/trendsAgent.js",
+    "sourcePath": "functions/agents/trendsAgent.js",
+    "updatedAt": "2025-07-02T02:27:43.913Z",
+    "createdAt": "2025-07-02T02:27:43.913Z"
+  },
+  "alignment-core": {
+    "name": "alignment-core",
+    "description": "",
+    "version": "v1.0.0",
+    "lastRunStatus": "unknown",
+    "agentType": "utility",
+    "enabled": true,
+    "docsUrl": "../functions/agents/alignment-core.js",
+    "sourcePath": "functions/agents/alignment-core.js",
+    "createdAt": "2025-07-02T02:27:29.171Z",
+    "updatedAt": "2025-07-02T02:27:43.913Z"
+  }
+}

--- a/functions/registry/updateAgentRegistry.js
+++ b/functions/registry/updateAgentRegistry.js
@@ -1,0 +1,58 @@
+const fs = require('fs');
+const path = require('path');
+
+/**
+ * Update config/agents.json with timestamps and ensure all agent files are listed.
+ * New agents discovered under functions/agents will be added automatically.
+ */
+async function updateRegistry() {
+  const agentsDir = path.join(__dirname, '..', 'agents');
+  const configPath = path.join(__dirname, '..', '..', 'config', 'agents.json');
+  const now = new Date().toISOString();
+
+  let registry = {};
+  if (fs.existsSync(configPath)) {
+    try {
+      registry = JSON.parse(fs.readFileSync(configPath, 'utf8'));
+    } catch (err) {
+      console.error('Failed to parse agents.json:', err);
+    }
+  }
+
+  const files = fs.readdirSync(agentsDir).filter(f => f.endsWith('.js'));
+  for (const file of files) {
+    const name = file.replace(/\.js$/, '').replace(/([A-Z])/g, '-$1').toLowerCase();
+    if (!registry[name]) {
+      registry[name] = {
+        name,
+        description: '',
+        version: 'v1.0.0',
+        lastRunStatus: 'unknown',
+        agentType: 'utility',
+        enabled: true,
+        docsUrl: `../functions/agents/${file}`,
+        sourcePath: `functions/agents/${file}`,
+        createdAt: now,
+        updatedAt: now
+      };
+    } else {
+      registry[name].updatedAt = now;
+      if (!registry[name].createdAt) registry[name].createdAt = now;
+    }
+  }
+
+  fs.writeFileSync(configPath, JSON.stringify(registry, null, 2));
+
+  // mirror under public for hosting
+  const publicPath = path.join(__dirname, '..', '..', 'public', 'config');
+  if (!fs.existsSync(publicPath)) fs.mkdirSync(publicPath, { recursive: true });
+  fs.writeFileSync(path.join(publicPath, 'agents.json'), JSON.stringify(registry, null, 2));
+
+  console.log('Agent registry updated.');
+}
+
+if (require.main === module) {
+  updateRegistry();
+}
+
+module.exports = { updateRegistry };

--- a/public/agent-hub.css
+++ b/public/agent-hub.css
@@ -1,0 +1,3 @@
+#agentsTable th, #agentsTable td {
+  @apply border px-2 py-1;
+}

--- a/public/agent-hub.html
+++ b/public/agent-hub.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>AgentHub Console</title>
+  <link href="https://cdn.jsdelivr.net/npm/tailwindcss@2/dist/tailwind.min.css" rel="stylesheet">
+  <link rel="stylesheet" href="agent-hub.css">
+  <script src="https://www.gstatic.com/firebasejs/9.6.10/firebase-app-compat.js"></script>
+  <script src="https://www.gstatic.com/firebasejs/9.6.10/firebase-auth-compat.js"></script>
+  <script src="https://www.gstatic.com/firebasejs/9.6.10/firebase-firestore-compat.js"></script>
+</head>
+<body class="bg-gray-50 p-4">
+  <div class="max-w-6xl mx-auto">
+    <h1 class="text-2xl font-bold mb-4">AgentHub Console</h1>
+    <table id="agentsTable" class="min-w-full bg-white text-sm"></table>
+  </div>
+  <script src="agent-hub.js"></script>
+</body>
+</html>

--- a/public/agent-hub.js
+++ b/public/agent-hub.js
@@ -1,0 +1,67 @@
+// Firebase config placeholder
+const firebaseConfig = {
+  apiKey: "YOUR_API_KEY",
+  authDomain: "YOUR_PROJECT_ID.firebaseapp.com",
+  projectId: "YOUR_PROJECT_ID"
+};
+firebase.initializeApp(firebaseConfig);
+const auth = firebase.auth();
+
+async function loadAgents() {
+  const res = await fetch('/config/agents.json');
+  const data = await res.json();
+  renderTable(data);
+}
+
+function renderTable(registry) {
+  const table = document.getElementById('agentsTable');
+  table.innerHTML = `<thead><tr>
+    <th>Name</th>
+    <th>Status</th>
+    <th>Version</th>
+    <th>Created</th>
+    <th>Updated</th>
+    <th>Docs</th>
+    <th>Enabled</th>
+    <th>Actions</th>
+  </tr></thead>`;
+  const tbody = document.createElement('tbody');
+  Object.values(registry).forEach(agent => {
+    const row = document.createElement('tr');
+    row.innerHTML = `
+      <td>${agent.name}</td>
+      <td>${agent.lastRunStatus}</td>
+      <td>${agent.version}</td>
+      <td>${agent.createdAt || ''}</td>
+      <td>${agent.updatedAt || ''}</td>
+      <td><a class="text-blue-600 underline" href="${agent.docsUrl}" target="_blank">README</a></td>
+      <td><input type="checkbox" ${agent.enabled ? 'checked' : ''} disabled></td>
+      <td>
+        <button class="bg-gray-200 px-2 py-1 mr-1" onclick="testAgent('${agent.name}')">Test Agent</button>
+        <button class="bg-gray-200 px-2 py-1" onclick="rerunAgent('${agent.name}')">Rerun</button>
+      </td>`;
+    tbody.appendChild(row);
+  });
+  table.appendChild(tbody);
+}
+
+async function testAgent(name) {
+  alert(`Test functionality for ${name} not implemented.`);
+}
+
+async function rerunAgent(name) {
+  const user = auth.currentUser;
+  if (!user) {
+    alert('Login required');
+    return;
+  }
+  const token = await user.getIdToken();
+  await fetch(`https://us-central1-${firebaseConfig.projectId}.cloudfunctions.net/retryAgentRun`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
+    body: JSON.stringify({ agentName: name, userId: user.uid })
+  });
+  alert('Agent re-run triggered');
+}
+
+loadAgents();

--- a/public/config/agents.json
+++ b/public/config/agents.json
@@ -1,0 +1,86 @@
+{
+  "roadmap-agent": {
+    "name": "roadmap-agent",
+    "description": "Generates personalized milestone plans for users",
+    "version": "v1.0.2",
+    "lastRunStatus": "unknown",
+    "agentType": "utility",
+    "enabled": true,
+    "docsUrl": "../functions/agents/roadmapAgent.js",
+    "sourcePath": "functions/agents/roadmapAgent.js",
+    "updatedAt": "2025-07-02T02:27:43.913Z",
+    "createdAt": "2025-07-02T02:27:43.913Z"
+  },
+  "resume-agent": {
+    "name": "resume-agent",
+    "description": "Creates short resume or LinkedIn summaries",
+    "version": "v1.0.3",
+    "lastRunStatus": "unknown",
+    "agentType": "utility",
+    "enabled": true,
+    "docsUrl": "../functions/agents/resumeAgent.js",
+    "sourcePath": "functions/agents/resumeAgent.js",
+    "updatedAt": "2025-07-02T02:27:43.913Z",
+    "createdAt": "2025-07-02T02:27:43.913Z"
+  },
+  "opportunity-agent": {
+    "name": "opportunity-agent",
+    "description": "Matches grants, internships and jobs",
+    "version": "v1.0.3",
+    "lastRunStatus": "unknown",
+    "agentType": "utility",
+    "enabled": true,
+    "docsUrl": "../functions/agents/opportunityAgent.js",
+    "sourcePath": "functions/agents/opportunityAgent.js",
+    "updatedAt": "2025-07-02T02:27:43.913Z",
+    "createdAt": "2025-07-02T02:27:43.913Z"
+  },
+  "anomaly-agent": {
+    "name": "anomaly-agent",
+    "description": "Detects unusual behavior across user runs",
+    "version": "v1.0.0",
+    "lastRunStatus": "unknown",
+    "agentType": "monitor",
+    "enabled": true,
+    "docsUrl": "../functions/agents/anomalyAgent.js",
+    "sourcePath": "functions/agents/anomalyAgent.js",
+    "updatedAt": "2025-07-02T02:27:43.913Z",
+    "createdAt": "2025-07-02T02:27:43.913Z"
+  },
+  "insights-agent": {
+    "name": "insights-agent",
+    "description": "Aggregates agent analytics and metrics",
+    "version": "v1.0.0",
+    "lastRunStatus": "unknown",
+    "agentType": "analytics",
+    "enabled": true,
+    "docsUrl": "../functions/agents/insightsAgent.js",
+    "sourcePath": "functions/agents/insightsAgent.js",
+    "updatedAt": "2025-07-02T02:27:43.913Z",
+    "createdAt": "2025-07-02T02:27:43.913Z"
+  },
+  "trends-agent": {
+    "name": "trends-agent",
+    "description": "Computes usage trends across all agents",
+    "version": "v1.0.0",
+    "lastRunStatus": "unknown",
+    "agentType": "analytics",
+    "enabled": true,
+    "docsUrl": "../functions/agents/trendsAgent.js",
+    "sourcePath": "functions/agents/trendsAgent.js",
+    "updatedAt": "2025-07-02T02:27:43.913Z",
+    "createdAt": "2025-07-02T02:27:43.913Z"
+  },
+  "alignment-core": {
+    "name": "alignment-core",
+    "description": "",
+    "version": "v1.0.0",
+    "lastRunStatus": "unknown",
+    "agentType": "utility",
+    "enabled": true,
+    "docsUrl": "../functions/agents/alignment-core.js",
+    "sourcePath": "functions/agents/alignment-core.js",
+    "createdAt": "2025-07-02T02:27:29.171Z",
+    "updatedAt": "2025-07-02T02:27:43.913Z"
+  }
+}


### PR DESCRIPTION
## Summary
- implement AgentHub UI (HTML/CSS/JS)
- add agent registry JSON and updater script
- mirror registry in `public/config`
- automate registry update through new GitHub workflow
- document AgentHub in README

## Testing
- `npm install` *(fails: Unable to fetch project info due to missing credentials)*
- `npm test` *(fails: Unable to detect a Project Id in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_6864988421248323942b1879d463f4cc