### PR TITLE
Add CI report tools and local agent runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,39 @@
+name: Agent Test Matrix
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  agent-tests:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - agent: roadmap-agent
+            test: testRoadmapAgent.js
+          - agent: resume-agent
+            test: testResumeAgent.js
+          - agent: opportunity-agent
+            test: testOpportunityAgent.js
+          - agent: anomaly-agent
+            test: testAnomalyAgent.js
+          - agent: insights-agent
+            test: testInsightsAgent.js
+          - agent: trends-agent
+            test: testTrendsAgent.js
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
+      - name: Install deps
+        working-directory: functions
+        run: npm install
+      - name: Run test
+        working-directory: functions
+        run: node ${{ matrix.test }}
+      - name: Update summary
+        if: always()
+        run: echo "${{ matrix.agent }}: ${{ job.status }}" >> $GITHUB_STEP_SUMMARY

--- a/ci-report.md
+++ b/ci-report.md
@@ -1,0 +1,9 @@
+# Agent Test Coverage
+
+✅ roadmap-agent - tested
+✅ resume-agent - tested
+✅ opportunity-agent - tested
+⚠️ anomaly-agent - failing
+✅ insights-agent - tested
+⚠️ trends-agent - failing
+❌ alignment-core - missing

--- a/config/agents.json
+++ b/config/agents.json
@@ -9,7 +9,11 @@
     "docsUrl": "../functions/agents/roadmapAgent.js",
     "sourcePath": "functions/agents/roadmapAgent.js",
     "updatedAt": "2025-07-02T02:27:43.913Z",
-    "createdAt": "2025-07-02T02:27:43.913Z"
+    "createdAt": "2025-07-02T02:27:43.913Z",
+    "tags": [
+      "utility"
+    ],
+    "lifecycle": "stable"
   },
   "resume-agent": {
     "name": "resume-agent",
@@ -21,7 +25,11 @@
     "docsUrl": "../functions/agents/resumeAgent.js",
     "sourcePath": "functions/agents/resumeAgent.js",
     "updatedAt": "2025-07-02T02:27:43.913Z",
-    "createdAt": "2025-07-02T02:27:43.913Z"
+    "createdAt": "2025-07-02T02:27:43.913Z",
+    "tags": [
+      "utility"
+    ],
+    "lifecycle": "stable"
   },
   "opportunity-agent": {
     "name": "opportunity-agent",
@@ -33,7 +41,11 @@
     "docsUrl": "../functions/agents/opportunityAgent.js",
     "sourcePath": "functions/agents/opportunityAgent.js",
     "updatedAt": "2025-07-02T02:27:43.913Z",
-    "createdAt": "2025-07-02T02:27:43.913Z"
+    "createdAt": "2025-07-02T02:27:43.913Z",
+    "tags": [
+      "utility"
+    ],
+    "lifecycle": "stable"
   },
   "anomaly-agent": {
     "name": "anomaly-agent",
@@ -45,7 +57,11 @@
     "docsUrl": "../functions/agents/anomalyAgent.js",
     "sourcePath": "functions/agents/anomalyAgent.js",
     "updatedAt": "2025-07-02T02:27:43.913Z",
-    "createdAt": "2025-07-02T02:27:43.913Z"
+    "createdAt": "2025-07-02T02:27:43.913Z",
+    "tags": [
+      "monitor"
+    ],
+    "lifecycle": "stable"
   },
   "insights-agent": {
     "name": "insights-agent",
@@ -57,7 +73,11 @@
     "docsUrl": "../functions/agents/insightsAgent.js",
     "sourcePath": "functions/agents/insightsAgent.js",
     "updatedAt": "2025-07-02T02:27:43.913Z",
-    "createdAt": "2025-07-02T02:27:43.913Z"
+    "createdAt": "2025-07-02T02:27:43.913Z",
+    "tags": [
+      "analytics"
+    ],
+    "lifecycle": "stable"
   },
   "trends-agent": {
     "name": "trends-agent",
@@ -69,11 +89,15 @@
     "docsUrl": "../functions/agents/trendsAgent.js",
     "sourcePath": "functions/agents/trendsAgent.js",
     "updatedAt": "2025-07-02T02:27:43.913Z",
-    "createdAt": "2025-07-02T02:27:43.913Z"
+    "createdAt": "2025-07-02T02:27:43.913Z",
+    "tags": [
+      "analytics"
+    ],
+    "lifecycle": "stable"
   },
   "alignment-core": {
     "name": "alignment-core",
-    "description": "",
+    "description": "TBD",
     "version": "v1.0.0",
     "lastRunStatus": "unknown",
     "agentType": "utility",
@@ -81,6 +105,10 @@
     "docsUrl": "../functions/agents/alignment-core.js",
     "sourcePath": "functions/agents/alignment-core.js",
     "createdAt": "2025-07-02T02:27:29.171Z",
-    "updatedAt": "2025-07-02T02:27:43.913Z"
+    "updatedAt": "2025-07-02T02:27:43.913Z",
+    "tags": [
+      "utility"
+    ],
+    "lifecycle": "stable"
   }
 }

--- a/devtools/agentRunner.js
+++ b/devtools/agentRunner.js
@@ -1,0 +1,42 @@
+const fs = require('fs');
+const path = require('path');
+const minimist = require('minimist');
+
+const args = minimist(process.argv.slice(2));
+const agentId = args.agent || process.env.AGENT;
+if (!agentId) {
+  console.error('Usage: node devtools/agentRunner.js --agent <agent-id> [--fn <function>] [--input "{...}"] [--user <id>]');
+  process.exit(1);
+}
+const userId = args.user || 'local-user';
+let input = {};
+if (args.input) {
+  try { input = JSON.parse(args.input); } catch (e) { console.error('Invalid JSON for --input'); process.exit(1); }
+}
+
+const config = JSON.parse(fs.readFileSync(path.join(__dirname,'..','config','agents.json'), 'utf8'));
+const info = config[agentId];
+if (!info) {
+  console.error(`Unknown agent: ${agentId}`);
+  process.exit(1);
+}
+const agentPath = path.join(__dirname, '..', info.sourcePath);
+const mod = require(agentPath);
+
+let fnName = args.fn;
+if (!fnName) {
+  fnName = Object.keys(mod).find(k => typeof mod[k] === 'function');
+}
+if (!fnName || typeof mod[fnName] !== 'function') {
+  console.error('Could not determine function to run. Available:', Object.keys(mod));
+  process.exit(1);
+}
+
+(async () => {
+  try {
+    const result = await mod[fnName](input, userId);
+    console.log('Agent output:', result);
+  } catch (err) {
+    console.error('Agent run failed:', err.message);
+  }
+})();

--- a/public/ci-report.json
+++ b/public/ci-report.json
@@ -1,0 +1,30 @@
+[
+  {
+    "agent": "roadmap-agent",
+    "status": "tested"
+  },
+  {
+    "agent": "resume-agent",
+    "status": "tested"
+  },
+  {
+    "agent": "opportunity-agent",
+    "status": "tested"
+  },
+  {
+    "agent": "anomaly-agent",
+    "status": "failing"
+  },
+  {
+    "agent": "insights-agent",
+    "status": "tested"
+  },
+  {
+    "agent": "trends-agent",
+    "status": "failing"
+  },
+  {
+    "agent": "alignment-core",
+    "status": "missing"
+  }
+]

--- a/public/config/agents.json
+++ b/public/config/agents.json
@@ -9,7 +9,11 @@
     "docsUrl": "../functions/agents/roadmapAgent.js",
     "sourcePath": "functions/agents/roadmapAgent.js",
     "updatedAt": "2025-07-02T02:27:43.913Z",
-    "createdAt": "2025-07-02T02:27:43.913Z"
+    "createdAt": "2025-07-02T02:27:43.913Z",
+    "tags": [
+      "utility"
+    ],
+    "lifecycle": "stable"
   },
   "resume-agent": {
     "name": "resume-agent",
@@ -21,7 +25,11 @@
     "docsUrl": "../functions/agents/resumeAgent.js",
     "sourcePath": "functions/agents/resumeAgent.js",
     "updatedAt": "2025-07-02T02:27:43.913Z",
-    "createdAt": "2025-07-02T02:27:43.913Z"
+    "createdAt": "2025-07-02T02:27:43.913Z",
+    "tags": [
+      "utility"
+    ],
+    "lifecycle": "stable"
   },
   "opportunity-agent": {
     "name": "opportunity-agent",
@@ -33,7 +41,11 @@
     "docsUrl": "../functions/agents/opportunityAgent.js",
     "sourcePath": "functions/agents/opportunityAgent.js",
     "updatedAt": "2025-07-02T02:27:43.913Z",
-    "createdAt": "2025-07-02T02:27:43.913Z"
+    "createdAt": "2025-07-02T02:27:43.913Z",
+    "tags": [
+      "utility"
+    ],
+    "lifecycle": "stable"
   },
   "anomaly-agent": {
     "name": "anomaly-agent",
@@ -45,7 +57,11 @@
     "docsUrl": "../functions/agents/anomalyAgent.js",
     "sourcePath": "functions/agents/anomalyAgent.js",
     "updatedAt": "2025-07-02T02:27:43.913Z",
-    "createdAt": "2025-07-02T02:27:43.913Z"
+    "createdAt": "2025-07-02T02:27:43.913Z",
+    "tags": [
+      "monitor"
+    ],
+    "lifecycle": "stable"
   },
   "insights-agent": {
     "name": "insights-agent",
@@ -57,7 +73,11 @@
     "docsUrl": "../functions/agents/insightsAgent.js",
     "sourcePath": "functions/agents/insightsAgent.js",
     "updatedAt": "2025-07-02T02:27:43.913Z",
-    "createdAt": "2025-07-02T02:27:43.913Z"
+    "createdAt": "2025-07-02T02:27:43.913Z",
+    "tags": [
+      "analytics"
+    ],
+    "lifecycle": "stable"
   },
   "trends-agent": {
     "name": "trends-agent",
@@ -69,11 +89,15 @@
     "docsUrl": "../functions/agents/trendsAgent.js",
     "sourcePath": "functions/agents/trendsAgent.js",
     "updatedAt": "2025-07-02T02:27:43.913Z",
-    "createdAt": "2025-07-02T02:27:43.913Z"
+    "createdAt": "2025-07-02T02:27:43.913Z",
+    "tags": [
+      "analytics"
+    ],
+    "lifecycle": "stable"
   },
   "alignment-core": {
     "name": "alignment-core",
-    "description": "",
+    "description": "TBD",
     "version": "v1.0.0",
     "lastRunStatus": "unknown",
     "agentType": "utility",
@@ -81,6 +105,10 @@
     "docsUrl": "../functions/agents/alignment-core.js",
     "sourcePath": "functions/agents/alignment-core.js",
     "createdAt": "2025-07-02T02:27:29.171Z",
-    "updatedAt": "2025-07-02T02:27:43.913Z"
+    "updatedAt": "2025-07-02T02:27:43.913Z",
+    "tags": [
+      "utility"
+    ],
+    "lifecycle": "stable"
   }
 }

--- a/public/devops.html
+++ b/public/devops.html
@@ -27,6 +27,7 @@
       <div id="summary" class="mb-4"></div>
       <div id="recent" class="mb-6"></div>
       <div id="failing" class="mb-6"></div>
+      <div id="coverage" class="mb-6"></div>
       <div id="commits" class="mb-6"></div>
       <div id="activity" class="mb-6"></div>
     </div>

--- a/public/devops.js
+++ b/public/devops.js
@@ -19,6 +19,7 @@ async function loadData() {
   renderFailing(anomaliesSnap.docs);
   renderCommits(commitSnap.docs);
   renderActivity(anomaliesSnap.docs);
+  loadCoverage();
 }
 
 function renderSummary(agentDocs) {
@@ -61,6 +62,27 @@ function renderCommits(commitDocs) {
     const div = document.createElement('div');
     div.textContent = `${data.sha} - ${data.author} - ${data.timestamp}`;
     commits.appendChild(div);
+  });
+}
+
+async function loadCoverage() {
+  try {
+    const res = await fetch('ci-report.json');
+    if (!res.ok) return;
+    const data = await res.json();
+    renderCoverage(data);
+  } catch (_) {
+    // ignore
+  }
+}
+
+function renderCoverage(list) {
+  const coverage = document.getElementById('coverage');
+  coverage.innerHTML = '<h2 class="text-xl font-semibold mb-2">CI Coverage</h2>';
+  list.forEach(item => {
+    const div = document.createElement('div');
+    div.textContent = `${item.agent} - ${item.status}`;
+    coverage.appendChild(div);
   });
 }
 

--- a/scripts/ciReport.js
+++ b/scripts/ciReport.js
@@ -1,0 +1,31 @@
+const fs = require('fs');
+const path = require('path');
+const { spawnSync } = require('child_process');
+
+const agents = JSON.parse(fs.readFileSync(path.join(__dirname,'..','config','agents.json'),'utf8'));
+
+function toPascal(str){
+  return str.split('-').map(s=>s.charAt(0).toUpperCase()+s.slice(1)).join('');
+}
+
+const results = [];
+for(const id of Object.keys(agents)){
+  const pascal = toPascal(id);
+  const testFile = path.join(__dirname,'..','functions',`test${pascal}.js`);
+  if(!fs.existsSync(testFile)){
+    results.push({agent:id,status:'missing'});
+    continue;
+  }
+  const run = spawnSync('node',[testFile],{stdio:'inherit'});
+  results.push({agent:id,status:run.status===0?'tested':'failing'});
+}
+
+let md = '# Agent Test Coverage\n\n';
+for(const r of results){
+  const sym = r.status==='tested'? '✅' : r.status==='missing'? '❌' : '⚠️';
+  md += `${sym} ${r.agent} - ${r.status}\n`;
+}
+
+console.log(md);
+fs.writeFileSync(path.join(__dirname,'..','ci-report.md'), md);
+fs.writeFileSync(path.join(__dirname,'..','public','ci-report.json'), JSON.stringify(results, null, 2));

--- a/scripts/updateAgentTemplate.js
+++ b/scripts/updateAgentTemplate.js
@@ -1,0 +1,18 @@
+const fs = require('fs');
+const path = require('path');
+const cfgPath = path.join(__dirname,'..','config','agents.json');
+const pubPath = path.join(__dirname,'..','public','config','agents.json');
+const data = JSON.parse(fs.readFileSync(cfgPath,'utf8'));
+let changed = false;
+for(const [id,info] of Object.entries(data)){
+  if(!info.tags){ info.tags = [info.agentType || '']; changed = true; }
+  if(!info.description){ info.description = 'TBD'; changed = true; }
+  if(!info.lifecycle){ info.lifecycle = 'stable'; changed = true; }
+}
+if(changed){
+  fs.writeFileSync(cfgPath, JSON.stringify(data,null,2));
+  fs.writeFileSync(pubPath, JSON.stringify(data,null,2));
+  console.log('Agent templates updated.');
+} else {
+  console.log('No updates needed.');
+}


### PR DESCRIPTION
## Summary
- add CI reporter script to run agent tests
- update agent metadata with a helper script
- create local devtools runner for agents
- generate CI coverage JSON/markdown
- add CI matrix workflow for individual agent tests
- show coverage in DevOps dashboard

## Testing
- `npm install` *(fails: Unable to detect Project Id)*
- `npm test` *(fails: Unable to detect Project Id)*
- `node scripts/ciReport.js` *(fails: Unable to detect Project Id)*
- `node scripts/updateAgentTemplate.js`


------
https://chatgpt.com/codex/tasks/task_e_68649b38d90483238ed2a947e0d9afbb