### PR TITLE
Add user dashboard for run history

### DIFF
--- a/public/user-dashboard.html
+++ b/public/user-dashboard.html
@@ -1,0 +1,62 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>User Run History</title>
+  <link href="https://cdn.jsdelivr.net/npm/tailwindcss@2/dist/tailwind.min.css" rel="stylesheet">
+  <script src="https://www.gstatic.com/firebasejs/9.6.10/firebase-app-compat.js"></script>
+  <script src="https://www.gstatic.com/firebasejs/9.6.10/firebase-auth-compat.js"></script>
+  <script src="https://www.gstatic.com/firebasejs/9.6.10/firebase-firestore-compat.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/chart.js@3.9.1/dist/chart.min.js"></script>
+</head>
+<body class="bg-gray-100">
+  <div class="container mx-auto p-4">
+    <h1 class="text-2xl font-bold mb-4">Agent Run History</h1>
+    <div id="loginSection" class="mb-4">
+      <input id="email" class="border p-2 mr-2" placeholder="Email">
+      <input id="password" type="password" class="border p-2 mr-2" placeholder="Password">
+      <button id="loginBtn" class="bg-blue-600 text-white px-4 py-2 rounded mr-2">Login</button>
+      <button id="googleBtn" class="bg-red-600 text-white px-4 py-2 rounded">Google</button>
+      <p id="loginStatus" class="text-sm mt-2"></p>
+    </div>
+    <div id="controls" class="hidden mb-4">
+      <div class="mb-2">
+        <label class="mr-2">Agent</label>
+        <select id="agentFilter" class="border p-1 mr-4"></select>
+        <label class="mr-2">Status</label>
+        <select id="statusFilter" class="border p-1 mr-4">
+          <option value="">All</option>
+          <option value="success">Success</option>
+          <option value="error">Error</option>
+          <option value="warning">Warning</option>
+        </select>
+        <label class="mr-2">From</label>
+        <input id="startDate" type="date" class="border p-1 mr-2">
+        <label class="mr-2">To</label>
+        <input id="endDate" type="date" class="border p-1 mr-4">
+        <label class="mr-2">Group By</label>
+        <select id="groupBy" class="border p-1 mr-4">
+          <option value="agent">Agent</option>
+          <option value="task">Task</option>
+        </select>
+        <button id="refreshBtn" class="bg-gray-200 px-2 py-1 rounded">Refresh</button>
+        <button id="logoutBtn" class="ml-4 bg-red-500 text-white px-2 py-1 rounded">Logout</button>
+      </div>
+    </div>
+    <div id="stats" class="mb-4"></div>
+    <canvas id="usageChart" class="mb-4"></canvas>
+    <div id="runsContainer"></div>
+  </div>
+
+  <div id="logModal" class="hidden fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center">
+    <div class="bg-white p-4 rounded w-11/12 md:w-2/3 lg:w-1/2 max-h-screen overflow-y-auto">
+      <button id="closeModal" class="float-right text-red-600">X</button>
+      <h2 class="text-xl font-semibold mb-2">Run Details</h2>
+      <div id="modalContent" class="text-sm whitespace-pre-wrap"></div>
+    </div>
+  </div>
+
+  <script src="user-dashboard.js"></script>
+</body>
+</html>

--- a/public/user-dashboard.js
+++ b/public/user-dashboard.js
@@ -1,0 +1,164 @@
+// Firebase config placeholder
+const firebaseConfig = {
+  apiKey: "YOUR_API_KEY",
+  authDomain: "YOUR_PROJECT_ID.firebaseapp.com",
+  projectId: "YOUR_PROJECT_ID"
+};
+firebase.initializeApp(firebaseConfig);
+const auth = firebase.auth();
+const db = firebase.firestore();
+
+let chart;
+
+function $(id) { return document.getElementById(id); }
+
+async function fetchRuns() {
+  const user = auth.currentUser;
+  if (!user) return [];
+
+  let query = db.collection('users').doc(user.uid).collection('agentRuns');
+  const agent = $('agentFilter').value;
+  const status = $('statusFilter').value;
+  const start = $('startDate').value;
+  const end = $('endDate').value;
+  if (agent) query = query.where('agentName', '==', agent);
+  if (status) query = query.where('status', '==', status);
+  if (start) query = query.where('timestamp', '>=', start);
+  if (end) query = query.where('timestamp', '<=', end + '\uf8ff');
+  query = query.orderBy('timestamp', 'desc').limit(100);
+  const snap = await query.get();
+  return snap.docs.map(d => ({ id: d.id, ...d.data() }));
+}
+
+function groupRuns(runs, key) {
+  const grouped = {};
+  runs.forEach(r => {
+    const k = key === 'task' ? (r.input && r.input.task) || 'unknown' : r.agentName;
+    if (!grouped[k]) grouped[k] = [];
+    grouped[k].push(r);
+  });
+  return grouped;
+}
+
+function renderStats(runs) {
+  const total = runs.length;
+  const failures = runs.filter(r => r.status !== 'success' && !r.resolved).length;
+  const recentAgents = [...new Set(runs.map(r => r.agentName))].slice(0,3).join(', ');
+  $('stats').textContent = `Runs: ${total} | Failures: ${failures} | Recent Agents: ${recentAgents}`;
+}
+
+function renderChart(runs) {
+  const counts = {};
+  runs.forEach(r => { counts[r.agentName] = (counts[r.agentName] || 0) + 1; });
+  const labels = Object.keys(counts);
+  const data = labels.map(l => counts[l]);
+  const ctx = $('usageChart').getContext('2d');
+  if (chart) chart.destroy();
+  chart = new Chart(ctx, {
+    type: 'bar',
+    data: { labels, datasets: [{ label: 'Runs', data, backgroundColor: 'rgba(54,162,235,0.6)' }] },
+    options: { responsive: true, plugins: { legend: { display: false } } }
+  });
+}
+
+function renderRuns(runs) {
+  const groupKey = $('groupBy').value;
+  const grouped = groupRuns(runs, groupKey);
+  const container = $('runsContainer');
+  container.innerHTML = '';
+  Object.keys(grouped).forEach(k => {
+    const details = document.createElement('details');
+    details.className = 'mb-4 bg-white p-2 border rounded';
+    const summary = document.createElement('summary');
+    summary.textContent = `${k} (${grouped[k].length})`;
+    details.appendChild(summary);
+    const table = document.createElement('table');
+    table.className = 'min-w-full text-sm mt-2';
+    table.innerHTML = `<thead><tr>
+        <th class="border px-2 py-1">Time</th>
+        <th class="border px-2 py-1">Agent</th>
+        <th class="border px-2 py-1">Status</th>
+        <th class="border px-2 py-1">Output</th>
+      </tr></thead>`;
+    const tbody = document.createElement('tbody');
+    grouped[k].forEach(r => {
+      const row = document.createElement('tr');
+      row.className = 'cursor-pointer hover:bg-gray-100';
+      row.innerHTML = `<td class="border px-2 py-1">${r.timestamp || ''}</td>
+        <td class="border px-2 py-1">${r.agentName}</td>
+        <td class="border px-2 py-1">${r.status}</td>
+        <td class="border px-2 py-1 truncate max-w-xs">${JSON.stringify(r.output).slice(0,40)}</td>`;
+      row.addEventListener('click', () => showModal(r));
+      tbody.appendChild(row);
+    });
+    table.appendChild(tbody);
+    details.appendChild(table);
+    container.appendChild(details);
+  });
+}
+
+function showModal(run) {
+  $('modalContent').textContent = JSON.stringify(run, null, 2);
+  $('logModal').classList.remove('hidden');
+}
+
+$('closeModal').addEventListener('click', () => {
+  $('logModal').classList.add('hidden');
+});
+
+async function loadRuns() {
+  const runs = await fetchRuns();
+  populateAgentFilter(runs);
+  renderStats(runs);
+  renderChart(runs);
+  renderRuns(runs);
+}
+
+function populateAgentFilter(runs) {
+  const select = $('agentFilter');
+  const agents = [...new Set(runs.map(r => r.agentName))];
+  select.innerHTML = '<option value="">All</option>' + agents.map(a => `<option value="${a}">${a}</option>`).join('');
+}
+
+$('loginBtn').addEventListener('click', async () => {
+  const email = $('email').value.trim();
+  const password = $('password').value;
+  $('loginStatus').textContent = '';
+  try {
+    await auth.signInWithEmailAndPassword(email, password);
+  } catch (err) {
+    $('loginStatus').textContent = err.message;
+  }
+});
+
+$('googleBtn').addEventListener('click', async () => {
+  const provider = new firebase.auth.GoogleAuthProvider();
+  $('loginStatus').textContent = '';
+  try {
+    await auth.signInWithPopup(provider);
+  } catch (err) {
+    $('loginStatus').textContent = err.message;
+  }
+});
+
+$('logoutBtn').addEventListener('click', async () => {
+  await auth.signOut();
+});
+
+$('refreshBtn').addEventListener('click', loadRuns);
+$('groupBy').addEventListener('change', loadRuns);
+$('statusFilter').addEventListener('change', loadRuns);
+$('agentFilter').addEventListener('change', loadRuns);
+$('startDate').addEventListener('change', loadRuns);
+$('endDate').addEventListener('change', loadRuns);
+
+auth.onAuthStateChanged(user => {
+  if (user) {
+    $('loginSection').classList.add('hidden');
+    $('controls').classList.remove('hidden');
+    loadRuns();
+  } else {
+    $('controls').classList.add('hidden');
+    $('loginSection').classList.remove('hidden');
+  }
+});


### PR DESCRIPTION
## Summary
- add `user-dashboard.html` for end users to view their run history
- implement `user-dashboard.js` to load runs from `/users/{uid}/agentRuns`, provide filters, grouping, modal view and chart

## Testing
- `npm install` *(install dependencies for tests)*
- `npm test` *(fails: Unable to detect a Project Id)*

------
https://chatgpt.com/codex/tasks/task_e_68649b6be4188323b13ccffda2a7d5eb