### PR TITLE
Implement AgentSync pubsub utility

### DIFF
--- a/functions/__tests__/agent-sync.test.js
+++ b/functions/__tests__/agent-sync.test.js
@@ -1,0 +1,24 @@
+const assert = require('assert');
+process.env.LOCAL_AGENT_RUN = '1';
+
+const { registerAgent, publish, subscribe } = require('../utils/agent-sync');
+
+async function runTest() {
+  registerAgent('test-agent');
+  const runId = 'run-1';
+  const payload = { foo: 'bar' };
+
+  const received = await new Promise(resolve => {
+    subscribe(runId, data => resolve(data));
+    publish(runId, payload);
+  });
+
+  assert.strictEqual(received.foo, 'bar');
+  assert.strictEqual(received._agentId, 'test-agent');
+  console.log('AgentSync test passed');
+}
+
+runTest().catch(err => {
+  console.error('AgentSync test failed', err);
+  process.exit(1);
+});

--- a/functions/utils/agent-sync.js
+++ b/functions/utils/agent-sync.js
@@ -1,0 +1,92 @@
+const admin = require('firebase-admin');
+
+let agentId = 'unknown-agent';
+const listeners = {};
+const localStore = {};
+
+function registerAgent(id) {
+  agentId = id || agentId;
+}
+
+function encryptPayload(data) {
+  // Placeholder for future encryption logic
+  return data;
+}
+
+function decryptPayload(data) {
+  // Placeholder for future decryption logic
+  return data;
+}
+
+async function publish(runId, payload = {}) {
+  const data = {
+    ...encryptPayload(payload),
+    _timestamp: new Date().toISOString(),
+    _agentId: agentId
+  };
+
+  if (process.env.LOCAL_AGENT_RUN) {
+    if (!localStore[runId]) localStore[runId] = [];
+    localStore[runId].push(data);
+    (listeners[runId] || []).forEach(cb => cb(decryptPayload(data)));
+    return;
+  }
+
+  const db = admin.firestore();
+  const docRef = db.collection('agentSync').doc(runId);
+
+  async function attempt(retries = 3) {
+    try {
+      await docRef.set({
+        latest: data,
+        updates: admin.firestore.FieldValue.arrayUnion(data)
+      }, { merge: true });
+    } catch (err) {
+      if (retries > 0) {
+        console.warn('AgentSync publish retry', err.message);
+        await new Promise(r => setTimeout(r, 1000));
+        await attempt(retries - 1);
+      } else {
+        console.error('AgentSync publish failed', err.message);
+      }
+    }
+  }
+
+  await attempt();
+}
+
+function subscribe(runId, callback) {
+  if (process.env.LOCAL_AGENT_RUN) {
+    if (!listeners[runId]) listeners[runId] = [];
+    listeners[runId].push(callback);
+    if (localStore[runId]) {
+      localStore[runId].forEach(data => callback(decryptPayload(data)));
+    }
+    return () => {
+      listeners[runId] = (listeners[runId] || []).filter(cb => cb !== callback);
+    };
+  }
+
+  const db = admin.firestore();
+  const docRef = db.collection('agentSync').doc(runId);
+  let unsubscribe;
+
+  function startListener() {
+    unsubscribe = docRef.onSnapshot(snap => {
+      const data = snap.data();
+      if (!data || !data.latest) return;
+      callback(decryptPayload(data.latest));
+    }, err => {
+      console.error('AgentSync subscribe error', err.message);
+      setTimeout(startListener, 1000);
+    });
+  }
+
+  startListener();
+
+  return () => {
+    if (unsubscribe) unsubscribe();
+  };
+}
+
+module.exports = { registerAgent, publish, subscribe };


### PR DESCRIPTION
## Summary
- add AgentSync utils for publishing/subscribing to run state
- create basic local-mode test

## Testing
- `node functions/__tests__/agent-sync.test.js`
- `npm test` *(fails: Decoding Firebase ID token failed)*

------
https://chatgpt.com/codex/tasks/task_e_6864a5337230832398d141be0c9c5ca1