### PR TITLE
Add real-time agent monitoring UI

### DIFF
--- a/public/agent-monitor.html
+++ b/public/agent-monitor.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Agent Run Monitor</title>
+  <link href="https://cdn.jsdelivr.net/npm/tailwindcss@2/dist/tailwind.min.css" rel="stylesheet">
+  <script src="https://www.gstatic.com/firebasejs/9.6.10/firebase-app-compat.js"></script>
+  <script src="https://www.gstatic.com/firebasejs/9.6.10/firebase-auth-compat.js"></script>
+  <script src="https://www.gstatic.com/firebasejs/9.6.10/firebase-firestore-compat.js"></script>
+</head>
+<body class="bg-gray-100">
+  <div class="container mx-auto p-4">
+    <h1 class="text-2xl font-bold mb-4">Agent Run Monitor</h1>
+
+    <div id="loginSection" class="mb-4">
+      <input id="email" class="border p-2 mr-2" placeholder="Email">
+      <input id="password" type="password" class="border p-2 mr-2" placeholder="Password">
+      <button id="loginBtn" class="bg-blue-600 text-white px-4 py-2 rounded mr-2">Login</button>
+      <button id="googleBtn" class="bg-red-600 text-white px-4 py-2 rounded">Google</button>
+      <p id="loginStatus" class="text-sm mt-2"></p>
+    </div>
+
+    <div id="controls" class="hidden mb-4">
+      <label class="mr-2">Agent</label>
+      <select id="agentFilter" class="border p-1 mr-4">
+        <option value="">All</option>
+      </select>
+
+      <label class="mr-2">Status</label>
+      <select id="statusFilter" class="border p-1 mr-4">
+        <option value="">All</option>
+        <option value="running">Running</option>
+        <option value="success">Success</option>
+        <option value="error">Error</option>
+      </select>
+
+      <label class="mr-2">
+        <input type="checkbox" id="autoScroll" class="mr-1" checked>Auto-scroll
+      </label>
+
+      <button id="logoutBtn" class="ml-4 bg-red-500 text-white px-2 py-1 rounded">Logout</button>
+    </div>
+
+    <div id="offlineMsg" class="hidden text-center text-red-600 mb-2">Offline - showing cached data</div>
+    <div id="runsContainer" class="space-y-2 max-h-[60vh] overflow-y-auto border bg-white p-2 rounded"></div>
+  </div>
+
+  <div id="timelineModal" class="hidden fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center">
+    <div class="bg-white p-4 rounded w-11/12 md:w-2/3 lg:w-1/2 max-h-screen overflow-y-auto">
+      <button id="closeModal" class="float-right text-red-600">X</button>
+      <h2 class="text-xl font-semibold mb-2">Run Timeline</h2>
+      <div id="modalContent" class="text-sm"></div>
+    </div>
+  </div>
+
+  <script src="agent-monitor.js"></script>
+</body>
+</html>

--- a/public/agent-monitor.js
+++ b/public/agent-monitor.js
@@ -1,0 +1,246 @@
+// Firebase config placeholder
+const firebaseConfig = {
+  apiKey: "YOUR_API_KEY",
+  authDomain: "YOUR_PROJECT_ID.firebaseapp.com",
+  projectId: "YOUR_PROJECT_ID"
+};
+
+let auth, db;
+try {
+  firebase.initializeApp(firebaseConfig);
+  auth = firebase.auth();
+  db = firebase.firestore();
+  db.enablePersistence({ synchronizeTabs: true }).catch(() => {});
+} catch (err) {
+  console.error('Firebase init failed', err);
+}
+
+let runs = [];
+let unsubscribeRuns = null;
+const stepListeners = {};
+
+function statusIcon(run) {
+  if (run.status === 'running') {
+    return '<span class="w-3 h-3 bg-blue-500 rounded-full inline-block mr-1 animate-ping"></span>';
+  }
+  if (run.status === 'success') {
+    return '<span class="text-green-600 font-semibold">\u2713</span>';
+  }
+  if (run.status === 'error') {
+    return '<span class="text-red-600 font-semibold">\u2717</span>';
+  }
+  return run.status || '';
+}
+
+function renderTimeline(steps) {
+  const wrapper = document.createElement('div');
+  wrapper.className = 'space-y-3 overflow-y-auto max-h-96 pr-2';
+  steps.forEach(step => {
+    const item = document.createElement('div');
+    item.className = 'border-l-2 border-gray-300 pl-4 relative';
+    const dot = document.createElement('span');
+    dot.className = 'w-2 h-2 bg-blue-500 rounded-full absolute -left-1 top-2';
+    item.appendChild(dot);
+    const header = document.createElement('div');
+    header.className = 'text-xs text-gray-500';
+    header.textContent = `${new Date(step.timestamp).toLocaleString()} • ${step.stepType || step.type}`;
+    const pre = document.createElement('pre');
+    pre.className = 'bg-gray-100 p-2 mt-1 rounded hidden text-xs';
+    pre.textContent = JSON.stringify(step, null, 2);
+    item.appendChild(header);
+    item.appendChild(pre);
+    item.addEventListener('click', () => pre.classList.toggle('hidden'));
+    wrapper.appendChild(item);
+  });
+  return wrapper;
+}
+
+async function openModal(runId) {
+  const userId = auth.currentUser.uid;
+  const runRef = db.collection('users').doc(userId).collection('agentRuns').doc(runId);
+  const content = document.getElementById('modalContent');
+  content.innerHTML = '';
+  try {
+    const stepsSnap = await runRef.collection('steps').orderBy('timestamp').get();
+    const steps = stepsSnap.docs.map(d => d.data());
+    if (steps.length) {
+      content.appendChild(renderTimeline(steps));
+    } else {
+      const doc = await runRef.get();
+      const data = doc.data() || {};
+      content.textContent = JSON.stringify({ input: data.input, output: data.output }, null, 2);
+    }
+  } catch (err) {
+    console.error('Failed to load steps', err);
+    content.textContent = 'Failed to load steps.';
+  }
+  document.getElementById('timelineModal').classList.remove('hidden');
+}
+
+document.getElementById('closeModal').addEventListener('click', () => {
+  document.getElementById('timelineModal').classList.add('hidden');
+});
+
+function updateAgentFilter() {
+  const select = document.getElementById('agentFilter');
+  const current = select.value;
+  select.innerHTML = '<option value="">All</option>';
+  const agents = Array.from(new Set(runs.map(r => r.agentName).filter(Boolean))).sort();
+  agents.forEach(name => {
+    const opt = document.createElement('option');
+    opt.value = name;
+    opt.textContent = name;
+    if (name === current) opt.selected = true;
+    select.appendChild(opt);
+  });
+}
+
+function renderRuns() {
+  const statusFilter = document.getElementById('statusFilter').value;
+  const agentFilter = document.getElementById('agentFilter').value;
+  const container = document.getElementById('runsContainer');
+  container.innerHTML = '';
+  const list = runs.filter(r => {
+    if (statusFilter && r.status !== statusFilter) return false;
+    if (agentFilter && r.agentName !== agentFilter) return false;
+    return true;
+  });
+  list.forEach(run => {
+    const div = document.createElement('div');
+    const highlight = run.highlight ? 'bg-yellow-50 ' : '';
+    div.className = highlight + 'border p-2 rounded cursor-pointer flex justify-between items-center';
+    div.innerHTML = `
+      <div>
+        <div class="font-semibold">${run.agentName}</div>
+        <div class="text-xs text-gray-500">${new Date(run.timestamp).toLocaleString()}</div>
+      </div>
+      <div class="flex items-center space-x-2">
+        ${statusIcon(run)}
+        ${run.phase ? `<span class="text-xs text-gray-600">${run.phase}</span>` : ''}
+        ${run.alignment && run.alignment.passed !== undefined ? `<span class="text-xs ${run.alignment.passed ? 'text-green-600' : 'text-red-600'}">${run.alignment.passed ? 'aligned' : 'flagged'}</span>` : ''}
+      </div>`;
+    div.addEventListener('click', () => openModal(run.id));
+    container.appendChild(div);
+  });
+  if (document.getElementById('autoScroll').checked) {
+    container.scrollTop = container.scrollHeight;
+  }
+}
+
+document.getElementById('statusFilter').addEventListener('change', renderRuns);
+document.getElementById('agentFilter').addEventListener('change', renderRuns);
+
+document.getElementById('loginBtn').addEventListener('click', async () => {
+  const email = document.getElementById('email').value.trim();
+  const password = document.getElementById('password').value;
+  const statusEl = document.getElementById('loginStatus');
+  statusEl.textContent = '';
+  try {
+    await auth.signInWithEmailAndPassword(email, password);
+  } catch (err) {
+    statusEl.textContent = err.message;
+  }
+});
+
+document.getElementById('googleBtn').addEventListener('click', async () => {
+  const provider = new firebase.auth.GoogleAuthProvider();
+  const statusEl = document.getElementById('loginStatus');
+  statusEl.textContent = '';
+  try {
+    await auth.signInWithPopup(provider);
+  } catch (err) {
+    statusEl.textContent = err.message;
+  }
+});
+
+document.getElementById('logoutBtn').addEventListener('click', async () => {
+  await auth.signOut();
+});
+
+function listenSteps(run) {
+  if (stepListeners[run.id]) return;
+  const userId = auth.currentUser.uid;
+  const ref = db
+    .collection('users')
+    .doc(userId)
+    .collection('agentRuns')
+    .doc(run.id)
+    .collection('steps')
+    .orderBy('timestamp', 'desc')
+    .limit(1);
+  stepListeners[run.id] = ref.onSnapshot(snap => {
+    if (!snap.empty) {
+      const step = snap.docs[0].data();
+      const idx = runs.findIndex(r => r.id === run.id);
+      if (idx > -1) {
+        runs[idx].phase = step.stepType || step.type;
+        renderRuns();
+      }
+    }
+  });
+}
+
+function processSnapshot(snapshot) {
+  const offline = snapshot.metadata.fromCache && !snapshot.metadata.hasPendingWrites;
+  document.getElementById('offlineMsg').classList.toggle('hidden', !offline);
+  snapshot.docChanges().forEach(change => {
+    const data = { id: change.doc.id, ...change.doc.data() };
+    if (change.type === 'removed') {
+      runs = runs.filter(r => r.id !== data.id);
+      if (stepListeners[data.id]) { stepListeners[data.id](); delete stepListeners[data.id]; }
+      return;
+    }
+    const idx = runs.findIndex(r => r.id === data.id);
+    if (idx >= 0) {
+      runs[idx] = { ...runs[idx], ...data, highlight: true };
+    } else {
+      runs.push({ ...data, highlight: true });
+    }
+    if (data.status === 'running') {
+      listenSteps(data);
+    } else if (stepListeners[data.id]) {
+      stepListeners[data.id]();
+      delete stepListeners[data.id];
+    }
+    setTimeout(() => {
+      const r = runs.find(x => x.id === data.id);
+      if (r) { delete r.highlight; renderRuns(); }
+    }, 3000);
+  });
+  runs.sort((a, b) => new Date(a.timestamp) - new Date(b.timestamp));
+  updateAgentFilter();
+  renderRuns();
+}
+
+function startListening() {
+  if (!auth.currentUser) return;
+  if (unsubscribeRuns) unsubscribeRuns();
+  Object.values(stepListeners).forEach(fn => fn());
+  for (const k in stepListeners) delete stepListeners[k];
+  runs = [];
+  const userId = auth.currentUser.uid;
+  const q = db
+    .collection('users')
+    .doc(userId)
+    .collection('agentRuns')
+    .orderBy('timestamp')
+    .limit(50);
+  unsubscribeRuns = q.onSnapshot(processSnapshot);
+}
+
+auth.onAuthStateChanged(user => {
+  if (user) {
+    document.getElementById('loginSection').classList.add('hidden');
+    document.getElementById('controls').classList.remove('hidden');
+    startListening();
+  } else {
+    if (unsubscribeRuns) unsubscribeRuns();
+    unsubscribeRuns = null;
+    Object.values(stepListeners).forEach(fn => fn());
+    for (const k in stepListeners) delete stepListeners[k];
+    runs = [];
+    renderRuns();
+    document.getElementById('loginSection').classList.remove('hidden');
+    document.getElementById('controls').classList.add('hidden');
+  }
+});


### PR DESCRIPTION
## Summary
- add **Agent Run Monitor** page for users to watch agent runs in real time
- implement `agent-monitor.js` to stream agentRuns with `onSnapshot`
- show status icons, filtering and auto‑scroll options
- display step timeline in a modal

## Testing
- `npm install` within `functions`
- `npm test` *(fails: Decoding Firebase ID token failed)*

------
https://chatgpt.com/codex/tasks/task_e_6864a51061f88323ad22a5b9d33a4c60