### PR TITLE
Implement AgentSync WebSocket bridge

### DIFF
--- a/functions/package.json
+++ b/functions/package.json
@@ -6,7 +6,8 @@
   },
   "dependencies": {
     "firebase-admin": "^11.0.0",
-    "firebase-functions": "^3.20.1"
+    "firebase-functions": "^3.20.1",
+    "ws": "^8.13.0"
   },
   "scripts": {
     "test": "node testRoadmapAgent.js && node testResumeAgent.js && node testOpportunityAgent.js && node testOnboardingFlow.js && node testInsightsAgent.js && node testAnomalyAgent.js && node testTrendsAgent.js && node testLifecycleFlow.js"

--- a/functions/utils/agent-sync-ws.js
+++ b/functions/utils/agent-sync-ws.js
@@ -1,0 +1,29 @@
+const WebSocket = require('ws');
+let wss;
+
+function initAgentSyncWs(server) {
+  if (wss) return wss;
+  wss = new WebSocket.Server({ noServer: true });
+  server.on('upgrade', (req, socket, head) => {
+    if (req.url === '/agent-sync') {
+      wss.handleUpgrade(req, socket, head, ws => {
+        wss.emit('connection', ws, req);
+      });
+    } else {
+      socket.destroy();
+    }
+  });
+  return wss;
+}
+
+function broadcast(runId, payload) {
+  if (!wss) return;
+  const message = JSON.stringify({ runId, payload });
+  for (const client of wss.clients) {
+    if (client.readyState === WebSocket.OPEN) {
+      client.send(message);
+    }
+  }
+}
+
+module.exports = { initAgentSyncWs, broadcast };

--- a/functions/utils/agent-sync.js
+++ b/functions/utils/agent-sync.js
@@ -1,4 +1,5 @@
 const admin = require('firebase-admin');
+const { broadcast } = require('./agent-sync-ws');
 
 let agentId = 'unknown-agent';
 const listeners = {};
@@ -29,6 +30,7 @@ async function publish(runId, payload = {}) {
     if (!localStore[runId]) localStore[runId] = [];
     localStore[runId].push(data);
     (listeners[runId] || []).forEach(cb => cb(decryptPayload(data)));
+    broadcast(runId, decryptPayload(data));
     return;
   }
 
@@ -53,6 +55,7 @@ async function publish(runId, payload = {}) {
   }
 
   await attempt();
+  broadcast(runId, decryptPayload(data));
 }
 
 function subscribe(runId, callback) {

--- a/index.js
+++ b/index.js
@@ -1,4 +1,7 @@
 const admin = require('firebase-admin');
+const express = require('express');
+const http = require('http');
+const { initAgentSyncWs } = require('./functions/utils/agent-sync-ws');
 
 if (!process.env.GOOGLE_CLOUD_PROJECT && !process.env.FIREBASE_PROJECT_ID) {
   process.env.FIREBASE_PROJECT_ID = 'demo-project';
@@ -23,3 +26,12 @@ admin.initializeApp({ credential, projectId });
 initializeApp({ projectId });
 
 console.log(`Firebase initialized for project ${projectId}`);
+
+const app = express();
+const server = http.createServer(app);
+initAgentSyncWs(server);
+
+const port = process.env.PORT || 3000;
+server.listen(port, () => {
+  console.log(`Server listening on port ${port}`);
+});

--- a/package.json
+++ b/package.json
@@ -11,6 +11,8 @@
   },
   "dependencies": {
     "firebase": "^9.6.10",
-    "firebase-admin": "^11.0.0"
+    "firebase-admin": "^11.0.0",
+    "express": "^4.18.2",
+    "ws": "^8.13.0"
   }
 }


### PR DESCRIPTION
## Summary
- add ws server helper for AgentSync
- broadcast AgentSync updates to sockets
- spin up Express/WS server in `index.js`
- install ws and express dependencies

## Testing
- `npm --prefix functions install` *(passed)*
- `npm --prefix functions test` *(failed: Decoding Firebase ID token failed)*

------
https://chatgpt.com/codex/tasks/task_e_6864a6c390308323a354f4a3e3a3595e