### PR TITLE
Enable real-time AgentSync feed

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -60,4 +60,5 @@ exports.getTrends = trends.getTrends;
 
 exports.updateAgentState = require('./ops/updateAgentState').updateAgentState;
 exports.logCommit = require('./ops/logCommit').logCommit;
+exports.agentSyncSubscribe = require('./ops/agentSyncSubscribe').agentSyncSubscribe;
 

--- a/functions/ops/agentSyncSubscribe.js
+++ b/functions/ops/agentSyncSubscribe.js
@@ -1,0 +1,61 @@
+const admin = require('firebase-admin');
+const functions = require('firebase-functions');
+const { subscribe } = require('../utils/agent-sync');
+
+/**
+ * Server-sent events endpoint for live AgentSync updates.
+ * Clients must provide ?runId and ?token query params.
+ */
+exports.agentSyncSubscribe = functions.https.onRequest(async (req, res) => {
+  res.set('Access-Control-Allow-Origin', '*');
+  res.set('Access-Control-Allow-Headers', 'Content-Type, Authorization');
+  if (req.method === 'OPTIONS') {
+    res.status(204).send('');
+    return;
+  }
+
+  const { runId, token } = req.query;
+  if (!runId || !token) {
+    res.status(400).json({ error: 'Missing parameters' });
+    return;
+  }
+
+  try {
+    const decoded = await admin.auth().verifyIdToken(token);
+    const db = admin.firestore();
+    const runDoc = await db
+      .collection('users')
+      .doc(decoded.uid)
+      .collection('agentRuns')
+      .doc(runId)
+      .get();
+    if (!runDoc.exists) {
+      res.status(404).json({ error: 'Run not found' });
+      return;
+    }
+  } catch (err) {
+    console.error('agentSyncSubscribe auth error', err.message);
+    res.status(401).json({ error: 'Unauthorized' });
+    return;
+  }
+
+  res.set({
+    'Cache-Control': 'no-cache',
+    'Content-Type': 'text/event-stream',
+    Connection: 'keep-alive'
+  });
+  res.flushHeaders();
+
+  const unsubscribe = subscribe(runId, data => {
+    try {
+      res.write(`data: ${JSON.stringify(data)}\n\n`);
+    } catch (e) {
+      // ignore write errors
+    }
+  });
+
+  req.on('close', () => {
+    unsubscribe();
+    res.end();
+  });
+});

--- a/functions/utils/step-logger.js
+++ b/functions/utils/step-logger.js
@@ -1,6 +1,7 @@
 const admin = require('firebase-admin');
 const fs = require('fs');
 const path = require('path');
+const { publish } = require('./agent-sync');
 
 function createStepLogger({ userId = 'unknown', runId = '', agentName = 'agent' }) {
   const localPath = path.join(__dirname, '..', 'steps.json');
@@ -41,6 +42,12 @@ function createStepLogger({ userId = 'unknown', runId = '', agentName = 'agent' 
       } catch (err) {
         console.error('step log failed', err.message);
       }
+    }
+
+    try {
+      await publish(runId, { stepType, input, output, durationMs });
+    } catch (err) {
+      console.error('AgentSync publish error', err.message);
     }
   };
 }


### PR DESCRIPTION
## Summary
- expose `agentSyncSubscribe` SSE endpoint for live updates
- emit AgentSync events from step logger and wrapper
- auto sign in anonymously on monitoring UI
- stream AgentSync events to dashboard and merge with Firestore

## Testing
- `npm --prefix functions install`
- `npm --prefix functions test` *(fails: Decoding Firebase ID token failed)*

------
https://chatgpt.com/codex/tasks/task_e_6864a6ba682c8323a473f027a134bbb3