### PR TITLE
Add replay logging with UI display

### DIFF
--- a/public/agent-monitor.html
+++ b/public/agent-monitor.html
@@ -18,3 +18,9 @@
   <button id="replayBtn" class="bg-blue-600 text-white px-2 py-1 rounded">Replay</button>
 </div>
 
+<!-- Replay Logs Accordion -->
+<details id="replayLogsSection" class="mt-4">
+  <summary class="cursor-pointer font-semibold">Replay Logs</summary>
+  <div id="replayLogs" class="mt-2 space-y-1 text-sm"></div>
+</details>
+

--- a/public/agent-monitor.js
+++ b/public/agent-monitor.js
@@ -22,5 +22,37 @@ const stepListeners = {};
 const syncStreams = {};
 let currentReplay = null;
 
+async function loadReplayLogs(runId) {
+  if (!auth || !auth.currentUser) return [];
+  const snap = await db
+    .collection('users')
+    .doc(auth.currentUser.uid)
+    .collection('agentRuns')
+    .doc(runId)
+    .collection('logs')
+    .orderBy('timestamp')
+    .get();
+  return snap.docs.map(d => d.data());
+}
+
+function renderReplayLogs(logs) {
+  const container = document.getElementById('replayLogs');
+  container.innerHTML = '';
+  logs.forEach(l => {
+    const div = document.createElement('div');
+    const params = l.params ? JSON.stringify(l.params) : '';
+    const err = l.error ? ` - Error: ${l.error}` : '';
+    div.textContent = `${l.timestamp} - ${l.event} ${params}${err}`;
+    container.appendChild(div);
+  });
+}
+
+async function showReplayLogs(runId) {
+  const logs = await loadReplayLogs(runId);
+  renderReplayLogs(logs);
+}
+
+window.showReplayLogs = showReplayLogs;
+
 // ... rest of the code continues unchanged
 


### PR DESCRIPTION
## Summary
- log replay events with `logReplayEvent`
- refactor replay agent run handling to always log actions
- expose replay log accordion in monitor UI
- fetch and display replay logs

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6864abc4a4c0832388c46f86c8a397ff