### PR TITLE
Implement live SSE replay updates

### DIFF
--- a/functions/utils/replay-stream.js
+++ b/functions/utils/replay-stream.js
@@ -49,6 +49,9 @@ class ReplayStream {
     this.speed = opts.speed || 1;
     this.annotations = [];
     this._stop = false;
+    this.paused = false;
+    this.index = 0;
+    this.total = 0;
   }
 
   async _fetchCollection(ref) {
@@ -114,15 +117,37 @@ class ReplayStream {
     return entry;
   }
 
+  async _emitState(extra = {}) {
+    try {
+      await publish(this.runId, {
+        type: 'replay-state',
+        index: this.index,
+        total: this.total,
+        paused: this.paused,
+        _replay: true,
+        ...extra
+      });
+    } catch (_) {}
+  }
+
   stop() {
     this._stop = true;
+    this.paused = true;
+    this._emitState({ status: 'paused' }).catch(() => {});
   }
 
   async play() {
     const timeline = await this._loadTimeline();
+    this.total = timeline.length;
+    this.index = 0;
+    this.paused = false;
+    await this._emitState({ status: 'running' });
     let prev = null;
     for (const item of timeline) {
-      if (this._stop) break;
+      if (this._stop) {
+        await this._emitState({ status: 'paused' });
+        break;
+      }
       if (prev) {
         const diff = new Date(item.timestamp) - new Date(prev.timestamp);
         if (diff > 0) {
@@ -134,7 +159,13 @@ class ReplayStream {
         ...item.data,
         _replay: true
       });
+      this.index++;
+      await this._emitState({ status: 'running' });
       prev = item;
+    }
+    if (!this._stop) {
+      this.paused = false;
+      await this._emitState({ status: 'completed' });
     }
     return this.annotations;
   }

--- a/public/agent-monitor.html
+++ b/public/agent-monitor.html
@@ -1,4 +1,5 @@
 <h2 class="text-xl font-semibold mb-2">Run Timeline</h2>
+<div id="replayStatus" class="text-sm text-gray-700 mb-2"></div>
 
 <!-- Session Replay Controls -->
 <div id="replayControls" class="hidden space-x-2 mb-2">

--- a/public/agent-monitor.js
+++ b/public/agent-monitor.js
@@ -21,6 +21,10 @@ let unsubscribeRuns = null;
 const stepListeners = {};
 const syncStreams = {};
 let currentReplay = null;
+let replaySource = null;
+let timelineSteps = [];
+let activeStep = -1;
+const statusEl = document.getElementById('replayStatus');
 
 async function loadReplayLogs(runId) {
   if (!auth || !auth.currentUser) return [];
@@ -54,5 +58,112 @@ async function showReplayLogs(runId) {
 
 window.showReplayLogs = showReplayLogs;
 
-// ... rest of the code continues unchanged
+function renderTimeline(steps, active = -1) {
+  const wrapper = document.createElement('div');
+  wrapper.className = 'space-y-3 overflow-y-auto max-h-96 pr-2';
+  steps.forEach((step, idx) => {
+    const item = document.createElement('div');
+    item.className = 'border-l-2 border-gray-300 pl-4 relative';
+    if (idx === active) item.classList.add('bg-yellow-50');
+    const dot = document.createElement('span');
+    dot.className = 'w-2 h-2 bg-blue-500 rounded-full absolute -left-1 top-2';
+    item.appendChild(dot);
+    const header = document.createElement('div');
+    header.className = 'text-xs text-gray-500';
+    header.textContent = `${new Date(step.timestamp).toLocaleString()} • ${step.type}`;
+    item.appendChild(header);
+    wrapper.appendChild(item);
+  });
+  return wrapper;
+}
+
+function updateTimeline() {
+  const container = document.getElementById('modalContent');
+  container.innerHTML = '';
+  container.appendChild(renderTimeline(timelineSteps, activeStep));
+  if (statusEl) {
+    if (activeStep >= 0) {
+      statusEl.textContent = `Step ${activeStep + 1} / ${timelineSteps.length}`;
+    } else {
+      statusEl.textContent = '';
+    }
+  }
+}
+
+async function sendReplayAction(runId, action, speed = 1) {
+  const user = auth.currentUser;
+  if (!user) return;
+  const token = await user.getIdToken();
+  const url = `https://us-central1-${firebaseConfig.projectId}.cloudfunctions.net/replayAgentRun`;
+  await fetch(url, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
+    body: JSON.stringify({ runId, action, speed })
+  });
+}
+
+async function startReplay() {
+  const params = new URLSearchParams(location.search);
+  const runId = params.get('runId');
+  if (!runId) return;
+  const speed = parseFloat(document.getElementById('replaySpeed').value) || 1;
+  timelineSteps = [];
+  activeStep = -1;
+  updateTimeline();
+  if (statusEl) statusEl.textContent = 'Starting...';
+  if (replaySource) replaySource.close();
+  await sendReplayAction(runId, 'stream', speed);
+  const token = await auth.currentUser.getIdToken();
+  const esUrl = `https://us-central1-${firebaseConfig.projectId}.cloudfunctions.net/agentSyncSubscribe?runId=${runId}&token=${token}`;
+  replaySource = new EventSource(esUrl);
+  replaySource.onmessage = evt => {
+    const data = JSON.parse(evt.data);
+    if (data.type === 'replay-state') {
+      activeStep = data.index - 1;
+      if (statusEl && data.status) {
+        statusEl.textContent = `${data.status} (${data.index}/${data.total})`;
+      }
+      updateTimeline();
+    } else {
+      const step = { type: data.stepType || data.type, timestamp: data.timestamp };
+      timelineSteps.push(step);
+      updateTimeline();
+    }
+  };
+  replaySource.onerror = () => {
+    if (statusEl) statusEl.textContent = 'disconnected';
+  };
+}
+
+document.getElementById('replayBtn').addEventListener('click', startReplay);
+
+document.getElementById('replayStart').addEventListener('click', () => {
+  const runId = new URLSearchParams(location.search).get('runId');
+  const speed = parseFloat(document.getElementById('replaySpeed').value) || 1;
+  if (runId) {
+    if (statusEl) statusEl.textContent = 'running';
+    sendReplayAction(runId, 'start', speed);
+  }
+});
+
+document.getElementById('replayPause').addEventListener('click', () => {
+  const runId = new URLSearchParams(location.search).get('runId');
+  if (runId) {
+    if (statusEl) statusEl.textContent = 'paused';
+    sendReplayAction(runId, 'pause');
+  }
+});
+
+document.getElementById('replayResume').addEventListener('click', () => {
+  const runId = new URLSearchParams(location.search).get('runId');
+  if (runId) {
+    if (statusEl) statusEl.textContent = 'running';
+    sendReplayAction(runId, 'resume');
+  }
+});
+
+document.getElementById('replayStep').addEventListener('click', () => {
+  const runId = new URLSearchParams(location.search).get('runId');
+  if (runId) sendReplayAction(runId, 'step');
+});
 


### PR DESCRIPTION
## Summary
- extend `ReplayStream` with state publishing
- stream replay updates with SSE and track progress
- update agent monitor UI to render timeline live

## Testing
- `node scripts/e2eReplayTest.js`
- `npm test` *(fails: Missing script)*
- `cd functions && npm test` *(fails: Firebase auth errors)*

------
https://chatgpt.com/codex/tasks/task_e_6864ae52877c8323ba365c0d6f5f9595