### PR TITLE
Implement replay log cleanup and error handling

### DIFF
--- a/.firebaserc
+++ b/.firebaserc
@@ -1,0 +1,5 @@
+{
+  "projects": {
+    "default": "super-intelligence-dev"
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,18 @@
 # Ignore node modules
 functions/node_modules/
 
+# Replay artifacts
+functions/replayLogs.json
+functions/steps.json
+functions/snapshots.json
+
+# Credentials
+serviceAccount.json
+**/serviceAccount.json
+
+# Test logs
+tests/**/*.log
+
 # Logs
 npm-debug.log*
 
@@ -8,3 +20,4 @@ npm-debug.log*
 .env
 
 node_modules/
+

--- a/functions/index.js
+++ b/functions/index.js
@@ -62,6 +62,7 @@ exports.getTrends = trends.getTrends;
 exports.updateAgentState = require('./ops/updateAgentState').updateAgentState;
 exports.logCommit = require('./ops/logCommit').logCommit;
 exports.agentSyncSubscribe = require('./ops/agentSyncSubscribe').agentSyncSubscribe;
+exports.cleanupOldReplays = require('./ops/cleanupOldReplays').cleanupOldReplays;
 
 exports.replayAgentRun = require('./replayAgentRun').replayAgentRun;
 

--- a/functions/ops/cleanupOldReplays.js
+++ b/functions/ops/cleanupOldReplays.js
@@ -1,0 +1,37 @@
+const admin = require('firebase-admin');
+const functions = require('firebase-functions');
+
+/**
+ * Scheduled cleanup for replay logs.
+ * Deletes logs older than 7 days unless persist is true.
+ * Skips runs that received AgentSync updates in the last 5 minutes.
+ */
+exports.cleanupOldReplays = functions.pubsub
+  .schedule('every 24 hours')
+  .onRun(async () => {
+    const db = admin.firestore();
+    const usersSnap = await db.collection('users').get();
+    const now = Date.now();
+    const threshold = new Date(now - 7 * 24 * 60 * 60 * 1000);
+
+    for (const user of usersSnap.docs) {
+      const runsSnap = await user.ref.collection('agentRuns').get();
+      for (const run of runsSnap.docs) {
+        const runId = run.id;
+        const syncDoc = await db.collection('agentSync').doc(runId).get();
+        const latest = syncDoc.data()?.latest?._timestamp;
+        if (latest && now - new Date(latest).getTime() < 5 * 60 * 1000) {
+          continue; // still streaming
+        }
+        const logsSnap = await run.ref
+          .collection('replayLogs')
+          .where('timestamp', '<', threshold.toISOString())
+          .get();
+        for (const log of logsSnap.docs) {
+          if (log.data().persist) continue;
+          await log.ref.delete();
+        }
+      }
+    }
+  });
+

--- a/functions/replayAgentRun.js
+++ b/functions/replayAgentRun.js
@@ -51,7 +51,8 @@ function runLoop(runId) {
   setTimeout(() => runLoop(runId), 500);
 }
 
-async function handleReplayAction({ userId, runId, action, speed = 1, isAdmin = false }) {
+async function handleReplayAction({ userId, runId, action, speed = 1, isAdmin = false, persist = false, message }) {
+  if (process.env.LOCAL_AGENT_RUN) persist = true;
   let result;
   let error;
   try {
@@ -83,6 +84,9 @@ async function handleReplayAction({ userId, runId, action, speed = 1, isAdmin = 
         }
       }
       result = { status: 'stepped' };
+    } else if (action === 'error') {
+      await logReplayEvent({ userId, runId, action: 'client-error', params: { message }, state: {}, error: message, persist });
+      result = { status: 'logged' };
     } else {
       throw new Error('Invalid action');
     }
@@ -100,7 +104,7 @@ async function handleReplayAction({ userId, runId, action, speed = 1, isAdmin = 
         }
       : {};
     try {
-      await logReplayEvent({ userId, runId, action, params: { speed }, state, error });
+      await logReplayEvent({ userId, runId, action, params: { speed }, state, error, persist });
     } catch (e) {
       console.error('replay log failed', e.message);
     }
@@ -130,7 +134,7 @@ exports.replayAgentRun = functions.https.onRequest(async (req, res) => {
       ? functions.config().debug.allowlist.split(',')
       : ['admin@example.com'];
 
-    const { runId, action = 'start', speed = 1 } = req.body || {};
+    const { runId, action = 'start', speed = 1, persist = false, message } = req.body || {};
     if (!runId) {
       res.status(400).json({ error: 'Missing runId' });
       return;
@@ -142,7 +146,9 @@ exports.replayAgentRun = functions.https.onRequest(async (req, res) => {
       runId,
       action,
       speed,
-      isAdmin: allowed.includes(decoded.email)
+      isAdmin: allowed.includes(decoded.email),
+      persist,
+      message
     });
     res.json(result);
   } catch (err) {

--- a/functions/utils/replay-stream.js
+++ b/functions/utils/replay-stream.js
@@ -20,7 +20,7 @@ function writeLocal(runId, entry) {
   fs.writeFileSync(replayLogPath, JSON.stringify(logs, null, 2));
 }
 
-async function logReplayEvent({ userId, runId, action, params = {}, state = {}, error }) {
+async function logReplayEvent({ userId, runId, action, params = {}, state = {}, error, persist = false }) {
   const entry = {
     timestamp: new Date().toISOString(),
     action,
@@ -28,6 +28,7 @@ async function logReplayEvent({ userId, runId, action, params = {}, state = {}, 
     state
   };
   if (error) entry.error = error;
+  if (persist) entry.persist = true;
 
   if (process.env.LOCAL_AGENT_RUN) {
     console.log('REPLAY EVENT', action, entry);

--- a/public/agent-monitor.html
+++ b/public/agent-monitor.html
@@ -1,5 +1,6 @@
 <h2 class="text-xl font-semibold mb-2">Run Timeline</h2>
 <div id="replayStatus" class="text-sm text-gray-700 mb-2"></div>
+<div id="errorBanner" class="hidden bg-red-200 text-red-800 p-2 rounded mb-2"></div>
 
 <!-- Session Replay Controls -->
 <div id="replayControls" class="hidden space-x-2 mb-2">
@@ -23,5 +24,6 @@
 <details id="replayLogsSection" class="mt-4">
   <summary class="cursor-pointer font-semibold">Replay Logs</summary>
   <div id="replayLogs" class="mt-2 space-y-1 text-sm"></div>
+  <button id="persistLogsBtn" class="mt-2 bg-gray-700 text-white px-2 py-1 rounded text-xs">Persist Logs</button>
 </details>
 


### PR DESCRIPTION
## Summary
- schedule `cleanupOldReplays` function to purge stale replay logs
- allow log persistence and error reporting from client
- surface replay errors in the UI and support persisting logs via button
- update SSE client to report failures gracefully
- ignore generated artifacts and add `.firebaserc`

## Testing
- `INJECT_DISCONNECT=1 node scripts/e2eReplayTest.js` *(fails: No step received within timeout)*
- `node scripts/e2eReplayTest.js` *(fails: No step received within timeout)*
- `firebase emulators:exec --project demo "echo running"`

------
https://chatgpt.com/codex/tasks/task_e_6864b0cf739c832399766f9936c30c53