### PR TITLE
Add Firebase token login

### DIFF
--- a/.github/workflows/firebase.yml
+++ b/.github/workflows/firebase.yml
@@ -7,6 +7,8 @@ on:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    env:
+      FIREBASE_TOKEN: ${{ secrets.FIREBASE_TOKEN }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
@@ -27,12 +29,5 @@ jobs:
       - name: Install Firebase CLI
         run: npm install -g firebase-tools
 
-      - name: Configure Firebase credentials
-        run: |
-          echo '${{ secrets.FIREBASE_SERVICE_ACCOUNT }}' > "$HOME/service-account.json"
-          echo "GOOGLE_APPLICATION_CREDENTIALS=$HOME/service-account.json" >> $GITHUB_ENV
-
       - name: Deploy to Firebase
         run: firebase deploy --only functions,firestore,hosting --project ${{ secrets.FIREBASE_PROJECT_ID }}
-        env:
-          GOOGLE_APPLICATION_CREDENTIALS: ${{ env.GOOGLE_APPLICATION_CREDENTIALS }}

--- a/README.md
+++ b/README.md
@@ -88,6 +88,14 @@ Inspired by principles from:
    firebase login --reauth
    ```
 
+### CI Deploys
+
+1. Generate a token locally using `firebase login:ci`.
+2. Store it as `FIREBASE_TOKEN` in GitHub Actions secrets or as
+   `firebase-ci-token` in Cloud Build's Secret Manager.
+3. The CI workflow injects this token so `firebase deploy` runs without
+   interactive login. If the token expires, re-run the command above.
+
 ### Debug Console
 
 Developers can review recent agent activity through `/debug.html` once

--- a/ci-report.md
+++ b/ci-report.md
@@ -13,3 +13,4 @@
 
 ## Build
 - 2025-07-02: Added `app.yaml` for Cloud Build and reauthenticated emulator with `firebase login --reauth`.
+- 2025-07-02: Configured CI to use `FIREBASE_TOKEN` for non-interactive `firebase deploy`.


### PR DESCRIPTION
## Summary
- inject `FIREBASE_TOKEN` secret into `firebase.yml`
- document token-based deploys in README
- update CI report on token use

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6864ca4f1a548323b87cdc3ff5737972