### PR TITLE
Add local dev start script

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,17 @@ Inspired by principles from:
    firebase login --reauth
    ```
 
+### Launching Local Dev Environment
+
+To run Firebase Hosting locally and start the frontend app:
+
+```bash
+./scripts/start-dev.sh
+```
+If you're not logged into Firebase, it will prompt you.
+
+On CI, auth is handled via `FIREBASE_TOKEN`.
+
 ### CI Deploys
 
 1. Generate a token locally using `firebase login:ci`.

--- a/ci-report.md
+++ b/ci-report.md
@@ -14,3 +14,4 @@
 ## Build
 - 2025-07-02: Added `app.yaml` for Cloud Build and reauthenticated emulator with `firebase login --reauth`.
 - 2025-07-02: Configured CI to use `FIREBASE_TOKEN` for non-interactive `firebase deploy`.
+- 2025-07-02: Added `scripts/start-dev.sh` for unified local Firebase and frontend startup.

--- a/scripts/start-dev.sh
+++ b/scripts/start-dev.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+# Ensure Firebase login locally
+firebase login || echo "Already logged in or using CI token"
+
+# Start only the hosting emulator
+firebase emulators:start --only hosting &
+
+# Launch frontend dev server
+cd frontend
+npm install
+npm run dev


### PR DESCRIPTION
## Summary
- add `scripts/start-dev.sh` to spin up Firebase hosting and the front-end
- document the script in the README
- log the update in `ci-report.md`

## Testing
- `npm --prefix functions install`
- `npm test --silent` *(fails: missing Firebase config token)*

------
https://chatgpt.com/codex/tasks/task_e_6864cb7fc3c4832391030309dc93bdad