### PR TITLE
Add unified Firebase dev script

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ Inspired by principles from:
 To run Firebase Hosting locally and start the frontend app:
 
 ```bash
-./scripts/start-dev.sh
+./start-dev.sh
 ```
 If you're not logged into Firebase, it will prompt you.
 

--- a/ci-report.md
+++ b/ci-report.md
@@ -14,4 +14,6 @@
 ## Build
 - 2025-07-02: Added `app.yaml` for Cloud Build and reauthenticated emulator with `firebase login --reauth`.
 - 2025-07-02: Configured CI to use `FIREBASE_TOKEN` for non-interactive `firebase deploy`.
-- 2025-07-02: Added `scripts/start-dev.sh` for unified local Firebase and frontend startup.
+
+## Local Launch Tools
+- 2025-07-02: Added `start-dev.sh` to automatically log in via `firebase login:ci` and run the frontend with the Hosting emulator.

--- a/start-dev.sh
+++ b/start-dev.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+set -e
+
+function cleanup() {
+  echo "\nShutting down services..."
+  if [[ -n "$EMULATOR_PID" ]]; then
+    kill "$EMULATOR_PID" 2>/dev/null || true
+  fi
+  exit 0
+}
+trap cleanup INT TERM
+
+echo "Checking Firebase authentication..."
+if ! firebase projects:list >/dev/null 2>&1; then
+  echo "Logging in via browser..."
+  firebase login:ci --no-localhost || {
+    echo "Firebase login failed"; exit 1; }
+else
+  echo "Firebase CLI already authenticated"
+fi
+
+echo "Starting Firebase Hosting emulator..."
+firebase emulators:start --only hosting &
+EMULATOR_PID=$!
+
+echo "Launching frontend dev server..."
+cd frontend
+npm install >/dev/null 2>&1
+npm run dev


### PR DESCRIPTION
## Summary
- add `start-dev.sh` for hosting emulator and front-end launch
- reference new script in README
- record tooling update in CI report

## Testing
- `bash ./start-dev.sh` *(fails: firebase: command not found)*
- `npm test` *(fails to execute fully due to Firebase warnings)*

------
https://chatgpt.com/codex/tasks/task_e_6864cecf76cc8323a6d2cdfd7dc3a01b