### PR TITLE
Check Java before starting emulators

### DIFF
--- a/scripts/start-dev.sh
+++ b/scripts/start-dev.sh
@@ -3,6 +3,16 @@
 # Ensure Firebase login locally
 firebase login || echo "Already logged in or using CI token"
 
+# Check for Java before starting emulators
+if ! java -version >/dev/null 2>&1; then
+  msg="Java is required for Firestore and PubSub emulators. Please install JDK 11+."
+  echo "$msg"
+  echo "https://adoptium.net"
+  log_file="$(dirname "$0")/../emulator-debug.log"
+  echo "$(date '+%Y-%m-%d %H:%M:%S') - $msg" >> "$log_file"
+  exit 0
+fi
+
 # Start only the hosting emulator
 firebase emulators:start --only hosting &
 

--- a/start-dev.sh
+++ b/start-dev.sh
@@ -23,6 +23,15 @@ if grep -q "FIREBASE_" .env 2>/dev/null; then
   echo "Environment setup detected."
 fi
 
+# Check for Java before starting emulators
+if ! java -version >/dev/null 2>&1; then
+  msg="Java is required for Firestore and PubSub emulators. Please install JDK 11+."
+  echo "$msg"
+  echo "https://adoptium.net"
+  echo "$(date '+%Y-%m-%d %H:%M:%S') - $msg" >> emulator-debug.log
+  exit 0
+fi
+
 echo "Starting Firebase Hosting emulator..."
 firebase emulators:start --only hosting &
 EMULATOR_PID=$!


### PR DESCRIPTION
## Summary
- ensure Java is installed before running firebase emulators
- log guidance to `emulator-debug.log`

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6865f196051483238368f28d98bcd327