### PR TITLE
Add Google Sign-In logic

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -1,7 +1,12 @@
+import { signInWithGoogle } from "./auth";
+
 function App() {
   return (
     <div className="App">
       <h1>🚀 React Frontend Ready - No Binary Assets</h1>
+      <button onClick={signInWithGoogle} className="google-btn">
+        Sign Up with Google
+      </button>
     </div>
   );
 }

--- a/frontend/src/auth.js
+++ b/frontend/src/auth.js
@@ -1,0 +1,7 @@
+import { getAuth, GoogleAuthProvider, signInWithPopup } from "firebase/auth";
+import { app } from "./firebase";
+
+const auth = getAuth(app);
+const provider = new GoogleAuthProvider();
+
+export const signInWithGoogle = () => signInWithPopup(auth, provider);


### PR DESCRIPTION
## Summary
- add Firebase Google auth helper
- wire sign-in button to use `signInWithGoogle`

## Testing
- `npm test` *(fails: Decoding Firebase ID token failed)*

------
https://chatgpt.com/codex/tasks/task_e_6865f4b7cf888323a87131383edfd966