### PR TITLE
Enable auth emulator

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -18,11 +18,23 @@
     ]
   },
   "emulators": {
+    "auth": {
+      "port": 9099
+    },
+    "functions": {
+      "port": 5001
+    },
     "firestore": {
       "port": 8080
     },
     "pubsub": {
       "port": 8085
+    },
+    "hosting": {
+      "port": 5000
+    },
+    "extensions": {
+      "port": 5001
     }
   }
 }

--- a/frontend/src/firebase.js
+++ b/frontend/src/firebase.js
@@ -1,6 +1,7 @@
 // Import the functions you need from the SDKs you need
 import { initializeApp } from "firebase/app";
 import { getAnalytics } from "firebase/analytics";
+import { getAuth, connectAuthEmulator } from "firebase/auth";
 // TODO: Add SDKs for Firebase products that you want to use
 // https://firebase.google.com/docs/web/setup#available-libraries
 
@@ -19,5 +20,10 @@ const firebaseConfig = {
 // Initialize Firebase
 const app = initializeApp(firebaseConfig);
 const analytics = getAnalytics(app);
+const auth = getAuth(app);
 
-export { app, analytics };
+if (window.location.hostname === "localhost") {
+  connectAuthEmulator(auth, "http://localhost:9099");
+}
+
+export { app, analytics, auth };


### PR DESCRIPTION
## Summary
- enable the Authentication emulator in `firebase.json`
- connect to the emulator in development in `frontend/src/firebase.js`

## Testing
- `npm test` *(fails: Decoding Firebase ID token failed)*
- `firebase emulators:start` *(fails: download failed, status 403)*

------
https://chatgpt.com/codex/tasks/task_e_6865f53710e08323bb6f2e26357cd9ba