### PR TITLE
Add alignment-core test and update coverage script

### DIFF
--- a/functions/testAlignmentCore.js
+++ b/functions/testAlignmentCore.js
@@ -1,0 +1,11 @@
+process.env.LOCAL_AGENT_RUN = '1';
+const { runAlignmentCheck } = require('./agents/alignment-core');
+
+(async () => {
+  const result = runAlignmentCheck({
+    agentName: 'alignment-core-test',
+    output: 'Guaranteed job offer for men only. $10k bootcamp with no aid.',
+    userData: { zipCode: '00501' }
+  });
+  console.log('Alignment check result:', JSON.stringify(result, null, 2));
+})();

--- a/scripts/ciReport.js
+++ b/scripts/ciReport.js
@@ -9,6 +9,8 @@ function toPascal(str){
 }
 
 const stepsPath = path.join(__dirname,'..','functions','steps.json');
+// optional additional tests not driven directly by agents.json
+const extraTests = [{ id: 'alignment-core', file: 'testAlignmentCore.js' }];
 
 const results = [];
 for(const id of Object.keys(agents)){
@@ -30,6 +32,14 @@ for(const id of Object.keys(agents)){
   const newSteps = after.slice(before.length).filter(s=>s.agent===id);
   const hasSteps = newSteps.length > 0;
   results.push({agent:id,status:run.status===0?'tested':'failing',steps:hasSteps});
+}
+
+for(const {id, file} of extraTests){
+  if(results.some(r => r.agent === id)) continue;
+  const testPath = path.join(__dirname,'..','functions',file);
+  if(!fs.existsSync(testPath)) continue;
+  const run = spawnSync('node',[testPath],{stdio:'inherit'});
+  results.push({agent:id,status:run.status===0?'tested':'failing',steps:false});
 }
 
 let md = '# Agent Test Coverage\n\n';


### PR DESCRIPTION
## Summary
- add `testAlignmentCore.js` for running `runAlignmentCheck`
- extend `ciReport.js` with optional test list so new test is covered

## Testing
- `npm test`
- `node scripts/ciReport.js`

------
https://chatgpt.com/codex/tasks/task_e_6865f8a32804832390687d698ccb5aa6