### PR TITLE
Centralize Firebase web config

### DIFF
--- a/public/agent-hub.html
+++ b/public/agent-hub.html
@@ -9,6 +9,7 @@
   <script src="https://www.gstatic.com/firebasejs/9.6.10/firebase-app-compat.js"></script>
   <script src="https://www.gstatic.com/firebasejs/9.6.10/firebase-auth-compat.js"></script>
   <script src="https://www.gstatic.com/firebasejs/9.6.10/firebase-firestore-compat.js"></script>
+  <script src="firebase-config.js"></script>
 </head>
 <body class="bg-gray-50 p-4">
   <div class="max-w-6xl mx-auto">

--- a/public/agent-hub.js
+++ b/public/agent-hub.js
@@ -1,10 +1,3 @@
-// Firebase config placeholder
-const firebaseConfig = {
-  apiKey: "YOUR_API_KEY",
-  authDomain: "YOUR_PROJECT_ID.firebaseapp.com",
-  projectId: "YOUR_PROJECT_ID"
-};
-firebase.initializeApp(firebaseConfig);
 const auth = firebase.auth();
 
 async function loadAgents() {

--- a/public/agent-monitor.js
+++ b/public/agent-monitor.js
@@ -1,13 +1,6 @@
-// Firebase config
-const firebaseConfig = {
-  apiKey: "YOUR_API_KEY",
-  authDomain: "YOUR_PROJECT_ID.firebaseapp.com",
-  projectId: "YOUR_PROJECT_ID"
-};
 
 let auth, db;
 try {
-  firebase.initializeApp(firebaseConfig);
   auth = firebase.auth();
   db = firebase.firestore();
   db.enablePersistence({ synchronizeTabs: true }).catch(() => {});

--- a/public/dashboard.html
+++ b/public/dashboard.html
@@ -7,6 +7,7 @@
   <link href="https://cdn.jsdelivr.net/npm/tailwindcss@2/dist/tailwind.min.css" rel="stylesheet">
   <script src="https://www.gstatic.com/firebasejs/9.6.10/firebase-app-compat.js"></script>
   <script src="https://www.gstatic.com/firebasejs/9.6.10/firebase-firestore-compat.js"></script>
+  <script src="firebase-config.js"></script>
 </head>
 <body class="bg-gray-100 p-6">
   <div class="max-w-3xl mx-auto">

--- a/public/dashboard.js
+++ b/public/dashboard.js
@@ -1,10 +1,3 @@
-// Firebase configuration placeholder - replace with your Firebase project values
-const firebaseConfig = {
-  apiKey: "YOUR_API_KEY",
-  authDomain: "YOUR_PROJECT_ID.firebaseapp.com",
-  projectId: "YOUR_PROJECT_ID",
-};
-firebase.initializeApp(firebaseConfig);
 const db = firebase.firestore();
 
 const statusEl = document.getElementById('status');

--- a/public/debug-anomalies.html
+++ b/public/debug-anomalies.html
@@ -8,6 +8,7 @@
   <script src="https://www.gstatic.com/firebasejs/9.6.10/firebase-app-compat.js"></script>
   <script src="https://www.gstatic.com/firebasejs/9.6.10/firebase-auth-compat.js"></script>
   <script src="https://www.gstatic.com/firebasejs/9.6.10/firebase-firestore-compat.js"></script>
+  <script src="firebase-config.js"></script>
 </head>
 <body class="bg-gray-100 p-4">
   <div class="max-w-5xl mx-auto">

--- a/public/debug-anomalies.js
+++ b/public/debug-anomalies.js
@@ -1,10 +1,3 @@
-// Firebase config placeholder
-const firebaseConfig = {
-  apiKey: "YOUR_API_KEY",
-  authDomain: "YOUR_PROJECT_ID.firebaseapp.com",
-  projectId: "YOUR_PROJECT_ID"
-};
-firebase.initializeApp(firebaseConfig);
 const auth = firebase.auth();
 const db = firebase.firestore();
 

--- a/public/debug-insights.html
+++ b/public/debug-insights.html
@@ -7,6 +7,7 @@
   <link href="https://cdn.jsdelivr.net/npm/tailwindcss@2/dist/tailwind.min.css" rel="stylesheet">
   <script src="https://www.gstatic.com/firebasejs/9.6.10/firebase-app-compat.js"></script>
   <script src="https://www.gstatic.com/firebasejs/9.6.10/firebase-auth-compat.js"></script>
+  <script src="firebase-config.js"></script>
 </head>
 <body class="bg-gray-100 p-4">
   <div class="max-w-5xl mx-auto">

--- a/public/debug-insights.js
+++ b/public/debug-insights.js
@@ -1,10 +1,3 @@
-// Firebase config placeholder
-const firebaseConfig = {
-  apiKey: "YOUR_API_KEY",
-  authDomain: "YOUR_PROJECT_ID.firebaseapp.com",
-  projectId: "YOUR_PROJECT_ID"
-};
-firebase.initializeApp(firebaseConfig);
 const auth = firebase.auth();
 
 const allowedEmails = ["admin@example.com"];

--- a/public/debug-trends.html
+++ b/public/debug-trends.html
@@ -8,6 +8,7 @@
   <script src="https://www.gstatic.com/firebasejs/9.6.10/firebase-app-compat.js"></script>
   <script src="https://www.gstatic.com/firebasejs/9.6.10/firebase-auth-compat.js"></script>
   <script src="https://www.gstatic.com/firebasejs/9.6.10/firebase-firestore-compat.js"></script>
+  <script src="firebase-config.js"></script>
 </head>
 <body class="bg-gray-100 p-4">
   <div class="max-w-5xl mx-auto">

--- a/public/debug-trends.js
+++ b/public/debug-trends.js
@@ -1,10 +1,3 @@
-// Firebase config placeholder
-const firebaseConfig = {
-  apiKey: "YOUR_API_KEY",
-  authDomain: "YOUR_PROJECT_ID.firebaseapp.com",
-  projectId: "YOUR_PROJECT_ID"
-};
-firebase.initializeApp(firebaseConfig);
 const auth = firebase.auth();
 const db = firebase.firestore();
 

--- a/public/debug.html
+++ b/public/debug.html
@@ -7,6 +7,7 @@
   <link href="https://cdn.jsdelivr.net/npm/tailwindcss@2/dist/tailwind.min.css" rel="stylesheet">
   <script src="https://www.gstatic.com/firebasejs/9.6.10/firebase-app-compat.js"></script>
   <script src="https://www.gstatic.com/firebasejs/9.6.10/firebase-auth-compat.js"></script>
+  <script src="firebase-config.js"></script>
 </head>
 <body class="bg-gray-100 p-4">
   <div class="max-w-5xl mx-auto">

--- a/public/debug.js
+++ b/public/debug.js
@@ -1,10 +1,3 @@
-// Firebase config placeholder
-const firebaseConfig = {
-  apiKey: "YOUR_API_KEY",
-  authDomain: "YOUR_PROJECT_ID.firebaseapp.com",
-  projectId: "YOUR_PROJECT_ID"
-};
-firebase.initializeApp(firebaseConfig);
 const auth = firebase.auth();
 
 const allowedEmails = ["admin@example.com"];

--- a/public/devops.html
+++ b/public/devops.html
@@ -9,6 +9,7 @@
   <script src="https://www.gstatic.com/firebasejs/9.6.10/firebase-app-compat.js"></script>
   <script src="https://www.gstatic.com/firebasejs/9.6.10/firebase-auth-compat.js"></script>
   <script src="https://www.gstatic.com/firebasejs/9.6.10/firebase-firestore-compat.js"></script>
+  <script src="firebase-config.js"></script>
 </head>
 <body class="bg-gray-50 p-4">
   <div class="max-w-6xl mx-auto">

--- a/public/devops.js
+++ b/public/devops.js
@@ -1,10 +1,3 @@
-// Firebase config placeholder
-const firebaseConfig = {
-  apiKey: "YOUR_API_KEY",
-  authDomain: "YOUR_PROJECT_ID.firebaseapp.com",
-  projectId: "YOUR_PROJECT_ID"
-};
-firebase.initializeApp(firebaseConfig);
 const auth = firebase.auth();
 const db = firebase.firestore();
 

--- a/public/firebase-config.js
+++ b/public/firebase-config.js
@@ -1,0 +1,10 @@
+// Centralized Firebase configuration
+// Replace these placeholders with real values or inject via environment variables during deployment
+const firebaseConfig = {
+  apiKey: "YOUR_API_KEY",
+  authDomain: "YOUR_PROJECT_ID.firebaseapp.com",
+  projectId: "YOUR_PROJECT_ID"
+};
+
+// Initialize Firebase once for all pages
+firebase.initializeApp(firebaseConfig);

--- a/public/index.html
+++ b/public/index.html
@@ -8,6 +8,7 @@
   <script src="https://www.gstatic.com/firebasejs/9.6.10/firebase-app-compat.js"></script>
   <script src="https://www.gstatic.com/firebasejs/9.6.10/firebase-auth-compat.js"></script>
   <script src="https://www.gstatic.com/firebasejs/9.6.10/firebase-firestore-compat.js"></script>
+  <script src="firebase-config.js"></script>
 </head>
 <body class="bg-gray-100 p-6">
   <div class="max-w-md mx-auto bg-white p-4 shadow">

--- a/public/onboarding.js
+++ b/public/onboarding.js
@@ -1,10 +1,3 @@
-// Firebase config placeholder
-const firebaseConfig = {
-  apiKey: "YOUR_API_KEY",
-  authDomain: "YOUR_PROJECT_ID.firebaseapp.com",
-  projectId: "YOUR_PROJECT_ID",
-};
-firebase.initializeApp(firebaseConfig);
 const auth = firebase.auth();
 const db = firebase.firestore();
 

--- a/public/user-dashboard.html
+++ b/public/user-dashboard.html
@@ -8,6 +8,7 @@
   <script src="https://www.gstatic.com/firebasejs/9.6.10/firebase-app-compat.js"></script>
   <script src="https://www.gstatic.com/firebasejs/9.6.10/firebase-auth-compat.js"></script>
   <script src="https://www.gstatic.com/firebasejs/9.6.10/firebase-firestore-compat.js"></script>
+  <script src="firebase-config.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/chart.js@3.9.1/dist/chart.min.js"></script>
 </head>
 <body class="bg-gray-100">

--- a/public/user-dashboard.js
+++ b/public/user-dashboard.js
@@ -1,15 +1,8 @@
-// Firebase config placeholder
-const firebaseConfig = {
-  apiKey: "YOUR_API_KEY",
-  authDomain: "YOUR_PROJECT_ID.firebaseapp.com",
-  projectId: "YOUR_PROJECT_ID"
-};
 
 let auth, db;
 let firebaseReady = true;
 
 try {
-  firebase.initializeApp(firebaseConfig);
   auth = firebase.auth();
   db = firebase.firestore();
 } catch (err) {


### PR DESCRIPTION
## Summary
- create `firebase-config.js`
- load shared Firebase config across public pages
- remove inline API config from individual scripts

## Testing
- `npm test` *(fails: Cannot find module 'firebase-admin')*

------
https://chatgpt.com/codex/tasks/task_e_6865f9faf668832382875b1b7ab49a84