### PR TITLE
Add translation utilities

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -67,3 +67,7 @@ exports.cleanupOldReplays = require('./ops/cleanupOldReplays').cleanupOldReplays
 
 exports.replayAgentRun = require('./replayAgentRun').replayAgentRun;
 
+// Translation utilities for localizing agent outputs
+exports.translateText = require('./utils/translate').translateText;
+exports.translateOutput = require('./utils/translate').translateOutput;
+

--- a/functions/utils/translate.js
+++ b/functions/utils/translate.js
@@ -1,0 +1,36 @@
+async function translateText(text = '', targetLang = 'en', sourceLang = 'auto') {
+  const url = 'https://translate.googleapis.com/translate_a/single' +
+    `?client=gtx&sl=${encodeURIComponent(sourceLang)}` +
+    `&tl=${encodeURIComponent(targetLang)}` +
+    `&dt=t&q=${encodeURIComponent(text)}`;
+  const res = await fetch(url);
+  if (!res.ok) {
+    throw new Error(`translateText ${res.status}`);
+  }
+  const data = await res.json();
+  const translated = (data[0] || []).map((part) => part[0]).join('');
+  return translated;
+}
+
+async function translateOutput(output, targetLang = 'en', sourceLang = 'auto') {
+  if (typeof output === 'string') {
+    return translateText(output, targetLang, sourceLang);
+  }
+  if (Array.isArray(output)) {
+    const res = [];
+    for (const item of output) {
+      res.push(await translateOutput(item, targetLang, sourceLang));
+    }
+    return res;
+  }
+  if (output && typeof output === 'object') {
+    const result = {};
+    for (const [key, value] of Object.entries(output)) {
+      result[key] = await translateOutput(value, targetLang, sourceLang);
+    }
+    return result;
+  }
+  return output;
+}
+
+module.exports = { translateText, translateOutput };


### PR DESCRIPTION
## Summary
- create translation helpers for translating strings and objects
- export translation utilities from Cloud Functions index

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6865ffeb6a2c8323992a93eb67976f16