### PR TITLE
Add locale-based translation wrappers

### DIFF
--- a/functions/agents/opportunityAgent.js
+++ b/functions/agents/opportunityAgent.js
@@ -1,5 +1,6 @@
 const { executeAgent } = require('../utils/agent-wrapper');
 const { logAgentOutput } = require('../logger');
+const { translateOutput } = require('../utils/aas-translate');
 
 /**
  * Generate a list of opportunities for the user.
@@ -25,15 +26,24 @@ async function generateOpportunities(userData = {}, userId = 'unknown', metadata
     }
   });
 
+  let finalOutput = result;
+  if (metadata.locale && metadata.locale !== 'en') {
+    try {
+      finalOutput = await translateOutput(result, metadata.locale);
+    } catch (err) {
+      console.error('opportunity-agent translation failed', err);
+    }
+  }
+
   await logAgentOutput({
     agentName: 'opportunity-agent',
     agentVersion,
     userId,
     inputSummary: metadata,
-    outputSummary: Array.isArray(result) ? result.map(o => o.title) : result
+    outputSummary: Array.isArray(finalOutput) ? finalOutput.map(o => o.title) : finalOutput
   });
 
-  return result;
+  return finalOutput;
 }
 
 module.exports = { generateOpportunities };

--- a/functions/agents/roadmapAgent.js
+++ b/functions/agents/roadmapAgent.js
@@ -1,7 +1,8 @@
 const { executeAgent } = require('../utils/agent-wrapper');
+const { translateOutput } = require('../utils/aas-translate');
 
-async function generateRoadmap(userData, userId = 'unknown') {
-  return executeAgent({
+async function generateRoadmap(userData, userId = 'unknown', metadata = {}) {
+  const result = await executeAgent({
     agentName: 'roadmap-agent',
     version: 'v1.0.2',
     userId,
@@ -14,7 +15,17 @@ async function generateRoadmap(userData, userId = 'unknown') {
       ];
     }
   });
+
+  let finalOutput = result;
+  if (metadata.locale && metadata.locale !== 'en') {
+    try {
+      finalOutput = await translateOutput(result, metadata.locale);
+    } catch (err) {
+      console.error('roadmap-agent translation failed', err);
+    }
+  }
+
+  return finalOutput;
 }
 
 module.exports = { generateRoadmap };
-

--- a/functions/utils/aas-translate.js
+++ b/functions/utils/aas-translate.js
@@ -1,0 +1,11 @@
+const fallback = require('./translate');
+let lib;
+try {
+  lib = require('ai-agent-systems');
+} catch (err) {
+  lib = {};
+}
+const translateText = lib.translateText || fallback.translateText;
+const translateOutput = lib.translateOutput || fallback.translateOutput;
+
+module.exports = { translateText, translateOutput };


### PR DESCRIPTION
## Summary
- add translation wrapper for `ai-agent-systems`
- translate resume, opportunity and roadmap outputs when locale is provided

## Testing
- `npm ci`
- `npm test` *(fails: Decoding Firebase ID token failed)*

------
https://chatgpt.com/codex/tasks/task_e_686601beff688323b5ab35b141de662a