### PR TITLE
Add website analysis flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,20 @@ to their docs and actions to re-run them. The registry is stored in
 `config/agents.json` and mirrored under `public/config/agents.json` for
 hosting.
 
+### Website Analysis Flow
+
+A new `runWebsiteAnalysis` Cloud Function executes the website-analysis
+flow ported from the **ai-agent-systems** repository. Trigger it with a
+POST request containing the target URL:
+
+```bash
+curl -X POST https://<REGION>-<PROJECT>.cloudfunctions.net/runWebsiteAnalysis \
+  -H "Content-Type: application/json" \
+  -d '{"url":"https://example.com"}'
+```
+
+The response contains the captured flow state and outputs for each step.
+
 ## Firebase Project Info
 
 - **Project Name:** Super Intelligence  

--- a/firebase.js
+++ b/firebase.js
@@ -1,0 +1,16 @@
+const admin = require('firebase-admin');
+const chalk = require('chalk');
+
+let db = null;
+try {
+  if (!admin.apps.length) {
+    admin.initializeApp({
+      credential: admin.credential.applicationDefault()
+    });
+  }
+  db = admin.firestore();
+} catch {
+  console.error(chalk.redBright("\uD83D\uDD25 Firebase config missing. Skipping initialization."));
+}
+
+module.exports = { admin, db };

--- a/functions/core/agentFlowEngine.js
+++ b/functions/core/agentFlowEngine.js
@@ -1,0 +1,135 @@
+const fs = require('fs');
+const path = require('path');
+const { writeDocument } = require('../db');
+
+const LOG_DIR = path.join(__dirname, '..', 'logs');
+const LOG_FILE = path.join(LOG_DIR, 'logs.json');
+
+function appendLog(entry) {
+  let logs = [];
+  try {
+    if (fs.existsSync(LOG_FILE)) {
+      logs = JSON.parse(fs.readFileSync(LOG_FILE, 'utf8'));
+    }
+  } catch {
+    logs = [];
+  }
+  logs.push(entry);
+  if (!fs.existsSync(LOG_DIR)) fs.mkdirSync(LOG_DIR, { recursive: true });
+  fs.writeFileSync(LOG_FILE, JSON.stringify(logs, null, 2));
+}
+
+function loadFlowConfig(flowId) {
+  const fp = path.join(__dirname, '..', 'flows', `${flowId}.json`);
+  if (!fs.existsSync(fp)) {
+    throw new Error(`Flow config ${flowId} not found`);
+  }
+  return JSON.parse(fs.readFileSync(fp, 'utf8'));
+}
+
+function loadAgent(agentName) {
+  const agentPath = path.join(__dirname, '..', 'agents', `${agentName}.js`);
+  try {
+    const mod = require(agentPath);
+    if (!mod || typeof mod.run !== 'function') {
+      throw new Error('missing run() export');
+    }
+    return mod;
+  } catch (err) {
+    throw new Error(`Failed to load agent '${agentName}': ${err.message}`);
+  }
+}
+
+async function runAgent(agentName, input) {
+  const agent = loadAgent(agentName);
+  return agent.run(input);
+}
+
+function resolvePlaceholders(obj, context) {
+  if (Array.isArray(obj)) {
+    return obj.map(v => resolvePlaceholders(v, context));
+  }
+  if (obj && typeof obj === 'object') {
+    const out = {};
+    for (const [k, v] of Object.entries(obj)) {
+      out[k] = resolvePlaceholders(v, context);
+    }
+    return out;
+  }
+  if (typeof obj === 'string' && obj.startsWith('$')) {
+    const pathParts = obj.slice(1).split('.');
+    let val = context;
+    for (const p of pathParts) {
+      if (val == null) return undefined;
+      val = val[p];
+    }
+    return val;
+  }
+  return obj;
+}
+
+/**
+ * Execute the website-analysis flow for a given URL
+ * @param {string} url Website to analyze
+ * @param {string} runId Identifier used for logging
+ * @param {Object} opts Additional options { userId, configId }
+ */
+async function runAgentFlow(url, runId, opts = {}) {
+  const { userId = 'anon', configId = 'website-analysis' } = opts;
+  const config = loadFlowConfig(configId);
+  const flowState = {
+    id: runId,
+    userId,
+    started: new Date().toISOString(),
+    steps: []
+  };
+
+  const input = { url };
+  const ctx = { input, steps: {} };
+
+  for (const step of config.steps) {
+    const id = step.id || step.agent;
+    const state = { id, agent: step.agent, started: new Date().toISOString() };
+    const stepInput = resolvePlaceholders(step.input || {}, { input, steps: ctx.steps });
+
+    try {
+      const result = await runAgent(step.agent, stepInput);
+      state.output = result.output;
+      state.explanation = result.explanation;
+      state.success = result.success !== false;
+      ctx.steps[id] = { output: result.output };
+    } catch (err) {
+      state.error = err.message;
+      state.success = false;
+      if (step.onError === 'warn') {
+        console.warn(`Flow step ${id} failed: ${err.message}`);
+      } else if (step.onError === 'fallback' && step.fallbackAgent) {
+        try {
+          const fbRes = await runAgent(step.fallbackAgent, stepInput);
+          state.fallback = { agent: step.fallbackAgent, output: fbRes.output };
+          state.success = fbRes.success !== false;
+          ctx.steps[id] = { output: fbRes.output };
+        } catch (fbErr) {
+          state.fallbackError = fbErr.message;
+        }
+      } else if (step.onError !== 'continue') {
+        flowState.steps.push(state);
+        await writeDocument(`flows/${userId}`, runId, flowState).catch(() => {});
+        appendLog({ flowId: runId, step: id, status: 'error', error: err.message, timestamp: new Date().toISOString() });
+        return flowState;
+      }
+    }
+
+    flowState.steps.push(state);
+    await writeDocument(`flows/${userId}`, runId, flowState).catch(() => {});
+    appendLog({ flowId: runId, step: id, status: state.success ? 'complete' : 'error', timestamp: new Date().toISOString() });
+  }
+
+  flowState.completed = true;
+  flowState.finished = new Date().toISOString();
+  await writeDocument(`flows/${userId}`, runId, flowState).catch(() => {});
+  appendLog({ flowId: runId, status: 'complete', timestamp: new Date().toISOString() });
+  return flowState;
+}
+
+module.exports = { runAgentFlow };

--- a/functions/db.js
+++ b/functions/db.js
@@ -1,0 +1,42 @@
+const { admin, db } = require('../firebase');
+const chalk = require('chalk');
+
+if (!db) {
+  console.error(chalk.redBright("\uD83D\uDD25 Firebase config missing. Skipping initialization."));
+}
+
+function coll(path) {
+  if (!db) return null;
+  const parts = path.split('/').filter(Boolean);
+  let ref = db;
+  while (parts.length) {
+    const col = parts.shift();
+    ref = ref.collection(col);
+    if (parts.length) {
+      const doc = parts.shift();
+      ref = ref.doc(doc);
+    }
+  }
+  return ref;
+}
+
+async function appendToCollection(path, data) {
+  const ref = coll(path);
+  if (!ref) return;
+  await ref.add({ ...data, timestamp: new Date().toISOString() });
+}
+
+async function readCollection(path) {
+  const ref = coll(path);
+  if (!ref) return [];
+  const snap = await ref.orderBy('timestamp').get();
+  return snap.docs.map(d => d.data());
+}
+
+async function writeDocument(path, id, data) {
+  const ref = coll(path);
+  if (!ref) return;
+  await ref.doc(id).set(data, { merge: true });
+}
+
+module.exports = { db, appendToCollection, readCollection, writeDocument };

--- a/functions/flows/website-analysis.json
+++ b/functions/flows/website-analysis.json
@@ -1,0 +1,40 @@
+{
+  "id": "website-analysis",
+  "steps": [
+    {
+      "id": "scrape",
+      "agent": "website-scanner-agent",
+      "input": { "url": "$input.url" },
+      "onError": "abort"
+    },
+    {
+      "id": "feature-extract",
+      "agent": "data-analyst-agent",
+      "input": { "agentOutputs": ["$steps.scrape.output"] },
+      "onError": "continue"
+    },
+    {
+      "id": "market-score",
+      "agent": "market-research-agent",
+      "input": { "analysis": "$steps.feature-extract.output" },
+      "onError": "continue"
+    },
+    {
+      "id": "refine",
+      "agent": "data-analyst-agent",
+      "input": {
+        "agentOutputs": [
+          "$steps.feature-extract.output",
+          "$steps.market-score.output"
+        ]
+      },
+      "onError": "continue"
+    },
+    {
+      "id": "plan",
+      "agent": "gtm-agent",
+      "input": { "analysis": "$steps.refine.output" },
+      "onError": "abort"
+    }
+  ]
+}

--- a/functions/index.js
+++ b/functions/index.js
@@ -71,3 +71,5 @@ exports.replayAgentRun = require('./replayAgentRun').replayAgentRun;
 exports.translateText = require('./utils/translate').translateText;
 exports.translateOutput = require('./utils/translate').translateOutput;
 
+exports.runWebsiteAnalysis = require('./runWebsiteAnalysis').runWebsiteAnalysis;
+

--- a/functions/runWebsiteAnalysis.js
+++ b/functions/runWebsiteAnalysis.js
@@ -1,0 +1,26 @@
+const functions = require('firebase-functions/v1');
+const { runAgentFlow } = require('./core/agentFlowEngine');
+
+exports.runWebsiteAnalysis = functions.https.onRequest(async (req, res) => {
+  res.set('Access-Control-Allow-Origin', '*');
+  res.set('Access-Control-Allow-Headers', 'Content-Type');
+  if (req.method === 'OPTIONS') {
+    res.status(204).send('');
+    return;
+  }
+
+  const { url, userId = 'anon' } = req.body || {};
+  if (!url) {
+    res.status(400).json({ error: 'Missing url' });
+    return;
+  }
+
+  try {
+    const runId = Date.now().toString();
+    const result = await runAgentFlow(url, runId, { userId, configId: 'website-analysis' });
+    res.json(result);
+  } catch (err) {
+    console.error('runWebsiteAnalysis error', err);
+    res.status(500).json({ error: err.message });
+  }
+});


### PR DESCRIPTION
## Summary
- bring in `agentFlowEngine` and support files from ai-agent-systems
- add `runWebsiteAnalysis` cloud function
- document the new flow

## Testing
- `npm install --prefix functions`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_686601ba2aac832397b1c05a97bcfbb1