### PR TITLE
Configure Firebase hosting targets

### DIFF
--- a/.firebaserc
+++ b/.firebaserc
@@ -5,6 +5,14 @@
     "production": "super-intelligence-7b653",
     "hybrid": "super-intelligence-7b653"
   },
-  "targets": {},
+  "targets": {
+    "super-intelligence-7b653": {
+      "hosting": {
+        "staging": ["staging"],
+        "production": ["production"],
+        "hybrid": ["hybrid"]
+      }
+    }
+  },
   "etags": {}
 }


### PR DESCRIPTION
## Summary
- map each hosting site to the appropriate target in `.firebaserc`

## Testing
- `npx firebase-tools deploy --only hosting` *(fails: ENOTEMPTY during package installation)*

------
https://chatgpt.com/codex/tasks/task_e_686617a224348323a06a35c15695b867