### PR TITLE
Add config sync script

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "index.js",
   "scripts": {
     "start": "firebase emulators:start",
-    "test": "npm --prefix functions test --silent",
+    "sync-agents": "node scripts/syncAgentsConfig.js",
+    "test": "npm run sync-agents && npm --prefix functions test --silent",
     "dev": "echo 'Dev server command missing. Please set it manually.'"
   },
   "engines": {

--- a/scripts/syncAgentsConfig.js
+++ b/scripts/syncAgentsConfig.js
@@ -1,0 +1,19 @@
+const fs = require('fs');
+const path = require('path');
+
+function syncAgents() {
+  const src = path.join(__dirname, '..', 'config', 'agents.json');
+  const destDir = path.join(__dirname, '..', 'public', 'config');
+  const dest = path.join(destDir, 'agents.json');
+  if (!fs.existsSync(destDir)) {
+    fs.mkdirSync(destDir, { recursive: true });
+  }
+  fs.copyFileSync(src, dest);
+  console.log(`Copied ${src} to ${dest}`);
+}
+
+if (require.main === module) {
+  syncAgents();
+}
+
+module.exports = { syncAgents };


### PR DESCRIPTION
## Summary
- copy agents.json from `config` to `public/config`
- expose new `sync-agents` npm script
- run the sync step as part of `npm test`

## Testing
- `npm test --silent >/tmp/npm_test.log && echo OK || echo FAIL`

------
https://chatgpt.com/codex/tasks/task_e_686617a655888323acff0e27f2cd5934