### PR TITLE
Fix opportunity agent logging

### DIFF
--- a/functions/agents/opportunityAgent.js
+++ b/functions/agents/opportunityAgent.js
@@ -39,7 +39,7 @@ async function generateOpportunities(userData = {}, userId = 'unknown', metadata
     agentName: 'opportunity-agent',
     agentVersion,
     userId,
-    inputSummary: metadata,
+    inputSummary: userData,
     outputSummary: Array.isArray(finalOutput) ? finalOutput.map(o => o.title) : finalOutput
   });
 

--- a/functions/testOpportunityAgent.js
+++ b/functions/testOpportunityAgent.js
@@ -1,6 +1,9 @@
 const admin = require('firebase-admin');
 process.env.LOCAL_AGENT_RUN = '1';
 const { generateOpportunities } = require('./agents/opportunityAgent');
+const fs = require('fs');
+const path = require('path');
+const assert = require('assert');
 
 // Initialize Firebase app for local testing if not already initialized
 try {
@@ -10,6 +13,14 @@ try {
 }
 
 (async () => {
-  const output = await generateOpportunities({ focus: 'tech' }, 'test-user');
+  const input = { focus: 'tech' };
+  const output = await generateOpportunities(input, 'test-user');
   console.log('Generated opportunities:', output);
+
+  const logPath = path.join(__dirname, 'logs.json');
+  const logs = JSON.parse(fs.readFileSync(logPath, 'utf8'));
+  const last = logs[logs.length - 1];
+  assert.strictEqual(last.agentName, 'opportunity-agent');
+  assert.deepStrictEqual(last.inputSummary, input);
+  console.log('Input summary logged correctly');
 })();


### PR DESCRIPTION
## Summary
- log user data in opportunityAgent instead of metadata
- verify logged input in opportunity agent test

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68661b6bc0d8832382c7fba04856476e