### PR TITLE
Add career flow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -90,3 +90,10 @@
 - 📅 Last updated: 2025-07-02
 - 🔗 [View source](https://github.com/Csp-Ai/Super-Intelligence/blob/main/functions/agents/trendsAgent.js)
 - 🧠 Description: Computes usage trends across all agents
+
+### flow-career
+- 📁 Path: `functions/flows/flow-career.js`
+- 🏷️ Tags: flow
+- 📅 Last updated: 2025-07-02
+- 🔗 [View source](https://github.com/Csp-Ai/Super-Intelligence/blob/main/functions/flows/flow-career.js)
+- 🧠 Description: Chains roadmap, resume, and opportunity agents using in-memory storage

--- a/functions/flows/flow-career.js
+++ b/functions/flows/flow-career.js
@@ -1,0 +1,50 @@
+const fs = require('fs');
+const path = require('path');
+
+const { generateRoadmap } = require('../agents/roadmapAgent');
+const { generateResumeSummary } = require('../agents/resumeAgent');
+const { generateOpportunities } = require('../agents/opportunityAgent');
+const memory = require('../utils/memory');
+
+function appendLog(runId, entry) {
+  const dir = path.join(__dirname, '..', '..', 'logs', 'flows');
+  const file = path.join(dir, `${runId}.json`);
+  if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
+  let data = [];
+  if (fs.existsSync(file)) {
+    try {
+      data = JSON.parse(fs.readFileSync(file, 'utf8'));
+      if (!Array.isArray(data)) data = [];
+    } catch (_) {
+      data = [];
+    }
+  }
+  data.push({ timestamp: new Date().toISOString(), ...entry });
+  fs.writeFileSync(file, JSON.stringify(data, null, 2));
+}
+
+async function runFlowCareer(userData = {}, runId, opts = {}) {
+  const userId = opts.userId || 'unknown';
+  if (!runId) runId = Date.now().toString();
+
+  // Roadmap step
+  const roadmap = await generateRoadmap(userData, userId);
+  memory.write(runId, { roadmap });
+  appendLog(runId, { agent: 'roadmap-agent', prompt: userData, score: 1 });
+
+  // Resume step
+  const resumeInput = { ...userData, roadmap };
+  const resume = await generateResumeSummary(resumeInput, userId);
+  memory.write(runId, { resume });
+  appendLog(runId, { agent: 'resume-agent', prompt: resumeInput, score: 1 });
+
+  // Opportunities step
+  const oppInput = { ...userData, resume, roadmap };
+  const opportunities = await generateOpportunities(oppInput, userId);
+  memory.write(runId, { opportunities });
+  appendLog(runId, { agent: 'opportunity-agent', prompt: oppInput, score: 1 });
+
+  return memory.read(runId);
+}
+
+module.exports = { runFlowCareer };

--- a/functions/utils/memory.js
+++ b/functions/utils/memory.js
@@ -1,0 +1,20 @@
+const store = {};
+
+function read(runId) {
+  return store[runId] ? { ...store[runId] } : {};
+}
+
+function write(runId, data = {}) {
+  if (!store[runId]) store[runId] = {};
+  Object.assign(store[runId], data);
+}
+
+function reset(runId) {
+  if (runId) {
+    delete store[runId];
+  } else {
+    Object.keys(store).forEach(key => delete store[key]);
+  }
+}
+
+module.exports = { read, write, reset };

--- a/scripts/runFlowCareer.js
+++ b/scripts/runFlowCareer.js
@@ -1,0 +1,13 @@
+const { runFlowCareer } = require('../functions/flows/flow-career');
+process.env.LOCAL_AGENT_RUN = '1';
+
+(async () => {
+  const runId = Date.now().toString();
+  const sample = {
+    fullName: 'Test Runner',
+    dreamOutcome: 'secure a great job',
+    focus: 'engineering'
+  };
+  const result = await runFlowCareer(sample, runId, { userId: 'cli-user' });
+  console.log('Flow result for', runId, result);
+})();


### PR DESCRIPTION
## Summary
- add simple memory module for flows
- chain roadmap, resume, and opportunity agents in `flow-career`
- log flow metadata to `logs/flows/<runId>.json`
- include CLI script to run the flow locally
- document new flow in `AGENTS.md`

## Testing
- `npm test --silent` *(fails: Decoding Firebase ID token failed)*

------
https://chatgpt.com/codex/tasks/task_e_68661baf1e5c8323b007c0c3643f9c28