### PR TITLE
Add binary file check to Firebase workflow

### DIFF
--- a/.github/workflows/firebase.yml
+++ b/.github/workflows/firebase.yml
@@ -5,7 +5,17 @@ on:
     branches: [main]
 
 jobs:
+  binary-check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+      - name: Detect binary files
+        run: |
+          git diff --cached --name-only | xargs file | grep -v 'text' && exit 1 || echo "No binaries"
+
   deploy:
+    needs: binary-check
     runs-on: ubuntu-latest
     env:
       FIREBASE_TOKEN: ${{ secrets.FIREBASE_TOKEN }}


### PR DESCRIPTION
## Summary
- check for binary files before deploying
- run deploy only after passing binary check

## Testing
- `npm test --silent` *(fails: Cannot find module '../core/agentFlowEngine')*

------
https://chatgpt.com/codex/tasks/task_e_68661e246d3c83239ad4b27d9d2390ad