### PR TITLE
Add Firebase hosting target check

### DIFF
--- a/.github/workflows/firebase.yml
+++ b/.github/workflows/firebase.yml
@@ -31,6 +31,9 @@ jobs:
           npm run lint --if-present
           npm test --silent
 
+      - name: Verify Firebase hosting targets
+        run: node scripts/checkFirebaseTargets.js
+
       - name: Install Firebase CLI
         run: npm install -g firebase-tools
 

--- a/scripts/checkFirebaseTargets.js
+++ b/scripts/checkFirebaseTargets.js
@@ -1,0 +1,42 @@
+const fs = require('fs');
+const path = require('path');
+
+function checkTargets() {
+  const rcPath = path.join(__dirname, '..', '.firebaserc');
+  const jsonPath = path.join(__dirname, '..', 'firebase.json');
+  const rc = JSON.parse(fs.readFileSync(rcPath, 'utf8'));
+  const config = JSON.parse(fs.readFileSync(jsonPath, 'utf8'));
+
+  const required = new Set();
+  const hostingConfig = config.hosting || [];
+  if (Array.isArray(hostingConfig)) {
+    for (const h of hostingConfig) {
+      if (h && h.target) required.add(h.target);
+    }
+  } else if (hostingConfig && hostingConfig.target) {
+    required.add(hostingConfig.target);
+  }
+
+  const defined = new Set();
+  if (rc.targets && typeof rc.targets === 'object') {
+    for (const project of Object.values(rc.targets)) {
+      if (project.hosting && typeof project.hosting === 'object') {
+        for (const t of Object.keys(project.hosting)) {
+          defined.add(t);
+        }
+      }
+    }
+  }
+
+  const missing = Array.from(required).filter(t => !defined.has(t));
+  if (missing.length > 0) {
+    console.error(`Missing Firebase hosting targets in .firebaserc: ${missing.join(', ')}`);
+    process.exit(1);
+  }
+}
+
+if (require.main === module) {
+  checkTargets();
+}
+
+module.exports = { checkTargets };


### PR DESCRIPTION
## Summary
- add script to verify firebase hosting targets exist in `.firebaserc`
- run the script in CI before deployment

## Testing
- `node scripts/checkFirebaseTargets.js`
- `npm test --silent` *(fails: Cannot find module '../core/agentFlowEngine')*

------
https://chatgpt.com/codex/tasks/task_e_68661e248ba48323b7a99e85b3b84e71