### PR TITLE
Update dashboard styling

### DIFF
--- a/public/agent-hub.html
+++ b/public/agent-hub.html
@@ -13,7 +13,7 @@
 </head>
 <body class="bg-gray-50 p-4">
   <div class="max-w-6xl mx-auto">
-    <h1 class="text-2xl font-bold mb-4">AgentHub Console</h1>
+    <h1 class="text-3xl font-extrabold mb-4">AgentHub Console</h1>
     <table id="agentsTable" class="min-w-full bg-white text-sm"></table>
   </div>
   <script src="agent-hub.js"></script>

--- a/public/dashboard.html
+++ b/public/dashboard.html
@@ -11,7 +11,7 @@
 </head>
 <body class="bg-gray-100 p-6">
   <div class="max-w-3xl mx-auto">
-    <h1 class="text-2xl font-semibold mb-4">Central Agent Dashboard</h1>
+    <h1 class="text-3xl font-extrabold mb-4">Central Agent Dashboard</h1>
     <div class="mb-4">
       <input id="userIdInput" type="text" placeholder="Enter user ID" class="border p-2 w-64 mr-2">
       <button id="fetchBtn" class="bg-blue-600 text-white px-4 py-2 rounded">Fetch</button>

--- a/public/dashboard.js
+++ b/public/dashboard.js
@@ -68,7 +68,7 @@ document.getElementById('fetchBtn').addEventListener('click', async () => {
 
 function renderRoadmap(steps) {
   const container = document.getElementById('roadmap');
-  container.innerHTML = '<h2 class="text-xl font-semibold mb-2">\uD83D\uDCCD Roadmap</h2>';
+  container.innerHTML = '<h2 class="text-2xl font-semibold mb-2">\uD83D\uDCCD Roadmap</h2>';
   if (!steps.length) {
     container.innerHTML += '<p>No roadmap found.</p>';
     return;
@@ -85,13 +85,13 @@ function renderRoadmap(steps) {
 
 function renderResume(summary) {
   const container = document.getElementById('resume');
-  container.innerHTML = '<h2 class="text-xl font-semibold mb-2">\uD83D\uDCC4 Resume</h2>';
+  container.innerHTML = '<h2 class="text-2xl font-semibold mb-2">\uD83D\uDCC4 Resume</h2>';
   container.innerHTML += summary ? `<p>${summary}</p>` : '<p>No resume summary found.</p>';
 }
 
 function renderOpportunities(list) {
   const container = document.getElementById('opportunities');
-  container.innerHTML = '<h2 class="text-xl font-semibold mb-2">\uD83D\uDD0D Opportunities</h2>';
+  container.innerHTML = '<h2 class="text-2xl font-semibold mb-2">\uD83D\uDD0D Opportunities</h2>';
   if (!list.length) {
     container.innerHTML += '<p>No opportunities found.</p>';
     return;

--- a/public/debug-anomalies.html
+++ b/public/debug-anomalies.html
@@ -12,7 +12,7 @@
 </head>
 <body class="bg-gray-100 p-4">
   <div class="max-w-5xl mx-auto">
-    <h1 class="text-2xl font-bold mb-4">Anomalies Console</h1>
+    <h1 class="text-3xl font-extrabold mb-4">Anomalies Console</h1>
     <div class="mb-2">
       <a href="debug.html" class="text-blue-600 underline mr-4">Logs</a>
       <a href="debug-insights.html" class="text-blue-600 underline mr-4">Insights</a>

--- a/public/debug-insights.html
+++ b/public/debug-insights.html
@@ -11,7 +11,7 @@
 </head>
 <body class="bg-gray-100 p-4">
   <div class="max-w-5xl mx-auto">
-    <h1 class="text-2xl font-bold mb-4">Insights Console</h1>
+    <h1 class="text-3xl font-extrabold mb-4">Insights Console</h1>
     <div class="mb-2">
       <a href="debug.html" class="text-blue-600 underline mr-4">Logs</a>
       <a href="debug-anomalies.html" class="text-blue-600 underline">Anomalies</a>

--- a/public/debug-insights.js
+++ b/public/debug-insights.js
@@ -22,7 +22,7 @@ function renderInsights(data) {
   Object.keys(data).forEach(agent => {
     const section = document.createElement('div');
     section.className = 'mb-6';
-    section.innerHTML = `<h2 class="text-xl font-semibold mb-2">${agent}</h2>`;
+    section.innerHTML = `<h2 class="text-2xl font-semibold mb-2">${agent}</h2>`;
     const pre = document.createElement('pre');
     pre.textContent = JSON.stringify(data[agent], null, 2);
     section.appendChild(pre);

--- a/public/debug-trends.html
+++ b/public/debug-trends.html
@@ -12,7 +12,7 @@
 </head>
 <body class="bg-gray-100 p-4">
   <div class="max-w-5xl mx-auto">
-    <h1 class="text-2xl font-bold mb-4">Trends Console</h1>
+    <h1 class="text-3xl font-extrabold mb-4">Trends Console</h1>
     <div class="mb-2">
       <a href="debug.html" class="text-blue-600 underline mr-4">Logs</a>
       <a href="debug-anomalies.html" class="text-blue-600 underline mr-4">Anomalies</a>

--- a/public/debug-trends.js
+++ b/public/debug-trends.js
@@ -18,7 +18,7 @@ function renderTrends(data) {
   Object.keys(data.metrics).forEach(agent => {
     const section = document.createElement('div');
     section.className = 'mb-6';
-    section.innerHTML = `<h2 class="text-xl font-semibold mb-2">${agent}</h2>`;
+    section.innerHTML = `<h2 class="text-2xl font-semibold mb-2">${agent}</h2>`;
     const pre = document.createElement('pre');
     pre.textContent = JSON.stringify(data.metrics[agent], null, 2);
     section.appendChild(pre);

--- a/public/debug.html
+++ b/public/debug.html
@@ -11,7 +11,7 @@
 </head>
 <body class="bg-gray-100 p-4">
   <div class="max-w-5xl mx-auto">
-    <h1 class="text-2xl font-bold mb-4">Agent Debug Console</h1>
+    <h1 class="text-3xl font-extrabold mb-4">Agent Debug Console</h1>
     <div class="mb-2">
       <a href="debug-anomalies.html" class="text-blue-600 underline mr-4">Anomalies</a>
       <a href="debug-insights.html" class="text-blue-600 underline">Insights</a>

--- a/public/debug.js
+++ b/public/debug.js
@@ -56,7 +56,7 @@ function renderLogs(logs) {
   Object.keys(grouped).forEach(agent => {
     const section = document.createElement('div');
     section.className = 'mb-6';
-    section.innerHTML = `<h2 class="text-xl font-semibold mb-2">${agent}</h2>`;
+    section.innerHTML = `<h2 class="text-2xl font-semibold mb-2">${agent}</h2>`;
     const table = document.createElement('table');
     table.className = 'min-w-full bg-white text-sm';
     table.innerHTML = `<thead><tr>

--- a/public/devops.html
+++ b/public/devops.html
@@ -13,7 +13,7 @@
 </head>
 <body class="bg-gray-50 p-4">
   <div class="max-w-6xl mx-auto">
-    <h1 class="text-2xl font-bold mb-4">DevOps Dashboard</h1>
+    <h1 class="text-3xl font-extrabold mb-4">DevOps Dashboard</h1>
     <div id="loginSection" class="mb-4">
       <input id="email" class="border p-2 mr-2" placeholder="Email">
       <input id="password" type="password" class="border p-2 mr-2" placeholder="Password">

--- a/public/devops.js
+++ b/public/devops.js
@@ -25,7 +25,7 @@ function renderSummary(agentDocs) {
 
 function renderRecent(agentDocs) {
   const recent = document.getElementById('recent');
-  recent.innerHTML = '<h2 class="text-xl font-semibold mb-2">Recently Modified</h2>';
+  recent.innerHTML = '<h2 class="text-2xl font-semibold mb-2">Recently Modified</h2>';
   agentDocs
     .sort((a, b) => (b.data().updatedAt || '').localeCompare(a.data().updatedAt || ''))
     .slice(0, 5)
@@ -38,7 +38,7 @@ function renderRecent(agentDocs) {
 
 function renderFailing(anomalyDocs) {
   const failing = document.getElementById('failing');
-  failing.innerHTML = '<h2 class="text-xl font-semibold mb-2">Top Failing Agents</h2>';
+  failing.innerHTML = '<h2 class="text-2xl font-semibold mb-2">Top Failing Agents</h2>';
   anomalyDocs.forEach(doc => {
     const data = doc.data();
     const div = document.createElement('div');
@@ -49,7 +49,7 @@ function renderFailing(anomalyDocs) {
 
 function renderCommits(commitDocs) {
   const commits = document.getElementById('commits');
-  commits.innerHTML = '<h2 class="text-xl font-semibold mb-2">Recent Commits</h2>';
+  commits.innerHTML = '<h2 class="text-2xl font-semibold mb-2">Recent Commits</h2>';
   commitDocs.forEach(doc => {
     const data = doc.data();
     const div = document.createElement('div');
@@ -71,7 +71,7 @@ async function loadCoverage() {
 
 function renderCoverage(list) {
   const coverage = document.getElementById('coverage');
-  coverage.innerHTML = '<h2 class="text-xl font-semibold mb-2">CI Coverage</h2>';
+  coverage.innerHTML = '<h2 class="text-2xl font-semibold mb-2">CI Coverage</h2>';
   list.forEach(item => {
     const div = document.createElement('div');
     div.textContent = `${item.agent} - ${item.status}`;
@@ -81,7 +81,7 @@ function renderCoverage(list) {
 
 function renderActivity(anomalyDocs) {
   const activity = document.getElementById('activity');
-  activity.innerHTML = '<h2 class="text-xl font-semibold mb-2">Activity Feed</h2>';
+  activity.innerHTML = '<h2 class="text-2xl font-semibold mb-2">Activity Feed</h2>';
   anomalyDocs.forEach(doc => {
     const data = doc.data();
     const div = document.createElement('div');

--- a/public/index.html
+++ b/public/index.html
@@ -12,7 +12,7 @@
 </head>
 <body class="bg-gray-100 p-6">
   <div class="max-w-md mx-auto bg-white p-4 shadow">
-    <h1 class="text-xl mb-4">Get Started</h1>
+    <h1 class="text-3xl font-extrabold mb-4">Get Started</h1>
     <input id="name" class="border p-2 w-full mb-2" placeholder="Full name" />
     <input id="email" class="border p-2 w-full mb-2" placeholder="Email" />
     <input id="password" type="password" class="border p-2 w-full mb-2" placeholder="Password" />

--- a/public/user-dashboard.html
+++ b/public/user-dashboard.html
@@ -13,7 +13,7 @@
 </head>
 <body class="bg-gray-100">
   <div class="container mx-auto p-4">
-    <h1 class="text-2xl font-bold mb-4">Agent Run History</h1>
+  <h1 class="text-3xl font-extrabold mb-4">Agent Run History</h1>
 
     <div id="loginSection" class="mb-4">
       <input id="email" class="border p-2 mr-2" placeholder="Email">
@@ -59,7 +59,7 @@
     </div>
 
     <div id="stats" class="mb-4"></div>
-    <canvas id="usageChart" class="mb-4"></canvas>
+    <canvas id="usageChart" class="mb-4 border-2 border-gray-300 shadow-lg rounded"></canvas>
 
     <div id="loadingSpinner" class="hidden text-center py-4">Loading...</div>
     <div id="emptyMsg" class="mb-4 text-center text-gray-500"></div>
@@ -69,7 +69,7 @@
   <div id="logModal" class="hidden fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center">
     <div class="bg-white p-4 rounded w-11/12 md:w-2/3 lg:w-1/2 max-h-screen overflow-y-auto">
       <button id="closeModal" class="float-right text-red-600">X</button>
-      <h2 class="text-xl font-semibold mb-2">Run Details</h2>
+      <h2 class="text-2xl font-semibold mb-2">Run Details</h2>
       <div id="modalContent" class="text-sm whitespace-pre-wrap mb-4"></div>
 
       <div id="feedbackSection" class="hidden mb-4">

--- a/public/user-dashboard.js
+++ b/public/user-dashboard.js
@@ -25,7 +25,7 @@ function renderRuns(runs) {
   }
   runs.forEach(run => {
     const div = document.createElement('div');
-    div.className = 'mb-2 p-2 border bg-white rounded cursor-pointer';
+    div.className = 'mb-4 p-4 bg-gray-50 border border-gray-200 rounded shadow cursor-pointer';
     div.innerHTML = `<div class="flex justify-between"><span>${run.agentName}</span><span>${new Date(run.timestamp).toLocaleString()}</span></div>`;
     div.addEventListener('click', () => openModal(run.id));
     container.appendChild(div);


### PR DESCRIPTION
## Summary
- improve heading typography across HTML pages
- add padding and subtle styling for metric cards
- highlight canvas element on the user dashboard

## Testing
- `npm test` *(fails: Cannot find module '../core/agentFlowEngine')*
- `npm install`

------
https://chatgpt.com/codex/tasks/task_e_6866245f17b48323a1546fe262ca41e6