### PR TITLE
Add CanvasNetwork component for animated agent pulses

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -1,12 +1,27 @@
+import { useRef } from "react";
 import { signInWithGoogle } from "./auth";
+import CanvasNetwork from "./components/CanvasNetwork";
 
 function App() {
+  const canvasRef = useRef(null);
+  const agents = [
+    { id: "core", x: 100, y: 120 },
+    { id: "mentor", x: 250, y: 60 },
+    { id: "opportunity", x: 400, y: 200 },
+  ];
+
+  const triggerPulse = id => {
+    canvasRef.current?.updateActivity(id);
+  };
+
   return (
     <div className="App">
       <h1>🚀 React Frontend Ready - No Binary Assets</h1>
       <button onClick={signInWithGoogle} className="google-btn">
         Sign Up with Google
       </button>
+      <button onClick={() => triggerPulse("core")}>Trigger Core Pulse</button>
+      <CanvasNetwork ref={canvasRef} agents={agents} width={500} height={300} />
     </div>
   );
 }

--- a/frontend/src/components/CanvasNetwork.js
+++ b/frontend/src/components/CanvasNetwork.js
@@ -1,0 +1,76 @@
+import { useEffect, useRef, useCallback } from 'react';
+
+// Small debounce hook
+export function useDebounce(fn, delay) {
+  const timeoutRef = useRef();
+  const callback = useCallback((...args) => {
+    clearTimeout(timeoutRef.current);
+    timeoutRef.current = setTimeout(() => fn(...args), delay);
+  }, [fn, delay]);
+  return callback;
+}
+
+import { forwardRef } from 'react';
+
+const CanvasNetwork = forwardRef(function CanvasNetwork({ width = 600, height = 400, agents = [] }, ref) {
+  const canvasRef = useRef(null);
+  // Agents are stored in a ref to avoid re-renders
+  const agentsRef = useRef([]);
+
+  // Initialize agent data only once
+  useEffect(() => {
+    agentsRef.current = agents.map(agent => ({
+      ...agent,
+      pulse: 0,
+    }));
+  }, [agents]);
+
+  const requestRef = useRef();
+
+  const draw = useCallback(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const ctx = canvas.getContext('2d');
+    ctx.clearRect(0, 0, width, height);
+
+    agentsRef.current.forEach(agent => {
+      // draw node
+      ctx.beginPath();
+      ctx.fillStyle = '#4f46e5'; // indigo-600
+      ctx.arc(agent.x, agent.y, 6, 0, Math.PI * 2);
+      ctx.fill();
+      // draw pulse if active
+      if (agent.pulse > 0) {
+        ctx.beginPath();
+        ctx.strokeStyle = 'rgba(99,102,241,' + agent.pulse / 20 + ')';
+        ctx.lineWidth = 2;
+        ctx.arc(agent.x, agent.y, 6 + agent.pulse, 0, Math.PI * 2);
+        ctx.stroke();
+        agent.pulse -= 0.5;
+      }
+    });
+
+    requestRef.current = requestAnimationFrame(draw);
+  }, [width, height]);
+
+  useEffect(() => {
+    requestRef.current = requestAnimationFrame(draw);
+    return () => cancelAnimationFrame(requestRef.current);
+  }, [draw]);
+
+  const debouncedActivity = useDebounce(id => {
+    const agent = agentsRef.current.find(a => a.id === id);
+    if (agent) {
+      agent.pulse = 10;
+    }
+  }, 200);
+
+  // Expose update function via ref
+  useEffect(() => {
+    canvasRef.current.updateActivity = debouncedActivity;
+  }, [debouncedActivity]);
+
+  return <canvas ref={canvasRef} width={width} height={height} />;
+});
+
+export default CanvasNetwork;


### PR DESCRIPTION
## Summary
- create `CanvasNetwork` component that uses `requestAnimationFrame`
- expose debounced `updateActivity` method through a forwarded ref
- render `CanvasNetwork` in `App` with a sample pulse trigger

## Testing
- `npm test --silent` *(fails: Cannot find module 'ajv')*

------
https://chatgpt.com/codex/tasks/task_e_6866246ef9d483238a36b57c900e7a29