### PR TITLE
Add Orbitron heading font

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -5,7 +5,18 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Sign Up</title>
   <link href="https://cdn.jsdelivr.net/npm/tailwindcss@2/dist/tailwind.min.css" rel="stylesheet">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Orbitron:wght@400;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="reduce-motion.css">
+  <style>
+    body {
+      font-family: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Helvetica Neue', sans-serif;
+    }
+    h1, h2, h3, h4, h5, h6 {
+      font-family: 'Orbitron', sans-serif;
+    }
+  </style>
   <script src="https://www.gstatic.com/firebasejs/9.6.10/firebase-app-compat.js"></script>
   <script src="https://www.gstatic.com/firebasejs/9.6.10/firebase-auth-compat.js"></script>
   <script src="https://www.gstatic.com/firebasejs/9.6.10/firebase-firestore-compat.js"></script>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,0 +1,12 @@
+module.exports = {
+  theme: {
+    extend: {
+      fontFamily: {
+        display: ['"Orbitron"', 'sans-serif'],
+        sans: ['system-ui', 'sans-serif']
+      }
+    }
+  },
+  variants: {},
+  plugins: [],
+}


### PR DESCRIPTION
## Summary
- add Orbitron via Google Fonts
- pair with system sans-serif for body text
- include a basic Tailwind config with font families

## Testing
- `npm install`
- `npm test --silent` *(fails: Cannot find module '../core/agentFlowEngine')*

------
https://chatgpt.com/codex/tasks/task_e_6866290ae2b08323afe8aa6c8e013be9