### PR TITLE
Add tooltip component for agent hub & devops

### DIFF
--- a/public/agent-hub.html
+++ b/public/agent-hub.html
@@ -7,6 +7,7 @@
   <link href="https://cdn.jsdelivr.net/npm/tailwindcss@2/dist/tailwind.min.css" rel="stylesheet">
   <link rel="stylesheet" href="reduce-motion.css">
   <link rel="stylesheet" href="agent-hub.css">
+  <link rel="stylesheet" href="tooltip.css">
   <script src="https://www.gstatic.com/firebasejs/9.6.10/firebase-app-compat.js"></script>
   <script src="https://www.gstatic.com/firebasejs/9.6.10/firebase-auth-compat.js"></script>
   <script src="https://www.gstatic.com/firebasejs/9.6.10/firebase-firestore-compat.js"></script>
@@ -18,6 +19,7 @@
     <table id="agentsTable" class="min-w-full bg-white text-sm"></table>
   </div>
   <script src="agent-hub.js"></script>
+  <script src="tooltip.js"></script>
   <label class="fixed bottom-2 right-2 bg-gray-200 p-1 rounded text-xs"><input type="checkbox" id="reduceMotionToggle"> Reduce Motion</label>
   <script src="reduce-motion.js"></script>
 </body>

--- a/public/agent-hub.js
+++ b/public/agent-hub.js
@@ -21,14 +21,15 @@ function renderTable(registry) {
   const tbody = document.createElement('tbody');
   Object.values(registry).forEach(agent => {
     const row = document.createElement('tr');
+    const desc = (agent.description || '').replace(/"/g, '&quot;');
     row.innerHTML = `
-      <td>${agent.name}</td>
-      <td>${agent.lastRunStatus}</td>
-      <td>${agent.version}</td>
-      <td>${agent.createdAt || ''}</td>
-      <td>${agent.updatedAt || ''}</td>
+      <td data-tooltip="Type: ${agent.agentType}. ${desc}">${agent.name}</td>
+      <td data-tooltip="Latest run status">${agent.lastRunStatus}</td>
+      <td data-tooltip="Semantic version">${agent.version}</td>
+      <td data-tooltip="Created at">${agent.createdAt || ''}</td>
+      <td data-tooltip="Last updated">${agent.updatedAt || ''}</td>
       <td><a class="text-blue-600 underline" href="${agent.docsUrl}" target="_blank">README</a></td>
-      <td><input type="checkbox" ${agent.enabled ? 'checked' : ''} disabled></td>
+      <td data-tooltip="Whether agent is enabled"><input type="checkbox" ${agent.enabled ? 'checked' : ''} disabled></td>
       <td>
         <button class="bg-gray-200 px-2 py-1 mr-1" onclick="testAgent('${agent.name}')">Test Agent</button>
         <button class="bg-gray-200 px-2 py-1" onclick="rerunAgent('${agent.name}')">Rerun</button>

--- a/public/devops.html
+++ b/public/devops.html
@@ -7,6 +7,7 @@
   <link href="https://cdn.jsdelivr.net/npm/tailwindcss@2/dist/tailwind.min.css" rel="stylesheet">
   <link rel="stylesheet" href="reduce-motion.css">
   <link rel="stylesheet" href="devops.css">
+  <link rel="stylesheet" href="tooltip.css">
   <script src="https://www.gstatic.com/firebasejs/9.6.10/firebase-app-compat.js"></script>
   <script src="https://www.gstatic.com/firebasejs/9.6.10/firebase-auth-compat.js"></script>
   <script src="https://www.gstatic.com/firebasejs/9.6.10/firebase-firestore-compat.js"></script>
@@ -37,6 +38,7 @@
     </div>
   </div>
   <script src="devops.js"></script>
+  <script src="tooltip.js"></script>
   <label class="fixed bottom-2 right-2 bg-gray-200 p-1 rounded text-xs"><input type="checkbox" id="reduceMotionToggle"> Reduce Motion</label>
   <script src="reduce-motion.js"></script>
 </body>

--- a/public/devops.js
+++ b/public/devops.js
@@ -19,6 +19,7 @@ async function loadData() {
 function renderSummary(agentDocs) {
   const summary = document.getElementById('summary');
   summary.className = 'mb-6 bg-white p-4 rounded shadow';
+  summary.setAttribute('data-tooltip', 'Overview of agent statuses');
   const total = agentDocs.length;
   const deprecated = agentDocs.filter(d => d.data().currentState === 'deprecated').length;
   const failing = agentDocs.filter(d => d.data().currentState === 'under-review' || d.data().currentState === 'offline').length;
@@ -28,6 +29,7 @@ function renderSummary(agentDocs) {
 function renderRecent(agentDocs) {
   const recent = document.getElementById('recent');
   recent.className = 'mb-6 bg-white p-4 rounded shadow';
+  recent.setAttribute('data-tooltip', 'Most recently updated agents');
   recent.innerHTML = '<h2 class="text-2xl font-semibold mb-2">Recently Modified</h2>';
   agentDocs
     .sort((a, b) => (b.data().updatedAt || '').localeCompare(a.data().updatedAt || ''))
@@ -42,6 +44,7 @@ function renderRecent(agentDocs) {
 function renderFailing(anomalyDocs) {
   const failing = document.getElementById('failing');
   failing.className = 'mb-6 bg-white p-4 rounded shadow';
+  failing.setAttribute('data-tooltip', 'Agents with frequent errors');
   failing.innerHTML = '<h2 class="text-2xl font-semibold mb-2">Top Failing Agents</h2>';
   anomalyDocs.forEach(doc => {
     const data = doc.data();
@@ -54,6 +57,7 @@ function renderFailing(anomalyDocs) {
 function renderCommits(commitDocs) {
   const commits = document.getElementById('commits');
   commits.className = 'mb-6 bg-white p-4 rounded shadow';
+  commits.setAttribute('data-tooltip', 'Recent commit history');
   commits.innerHTML = '<h2 class="text-2xl font-semibold mb-2">Recent Commits</h2>';
   commitDocs.forEach(doc => {
     const data = doc.data();
@@ -77,6 +81,7 @@ async function loadCoverage() {
 function renderCoverage(list) {
   const coverage = document.getElementById('coverage');
   coverage.className = 'mb-6 bg-white p-4 rounded shadow';
+  coverage.setAttribute('data-tooltip', 'CI test coverage report');
   coverage.innerHTML = '<h2 class="text-2xl font-semibold mb-2">CI Coverage</h2>';
   list.forEach(item => {
     const div = document.createElement('div');
@@ -88,6 +93,7 @@ function renderCoverage(list) {
 function renderActivity(anomalyDocs) {
   const activity = document.getElementById('activity');
   activity.className = 'mb-6 bg-white p-4 rounded shadow';
+  activity.setAttribute('data-tooltip', 'Latest anomaly messages');
   activity.innerHTML = '<h2 class="text-2xl font-semibold mb-2">Activity Feed</h2>';
   anomalyDocs.forEach(doc => {
     const data = doc.data();

--- a/public/tooltip.css
+++ b/public/tooltip.css
@@ -1,0 +1,13 @@
+.tooltip {
+  position: absolute;
+  background-color: rgba(55, 65, 81, 0.9);
+  color: #fff;
+  font-size: 0.75rem;
+  padding: 0.25rem 0.5rem;
+  border-radius: 0.25rem;
+  pointer-events: none;
+  z-index: 50;
+}
+.tooltip.hidden {
+  display: none;
+}

--- a/public/tooltip.js
+++ b/public/tooltip.js
@@ -1,0 +1,25 @@
+(function(){
+  const tooltip = document.createElement('div');
+  tooltip.className = 'tooltip hidden';
+  document.body.appendChild(tooltip);
+
+  function showTooltip(el) {
+    tooltip.textContent = el.getAttribute('data-tooltip');
+    const rect = el.getBoundingClientRect();
+    tooltip.style.top = rect.bottom + window.scrollY + 6 + 'px';
+    tooltip.style.left = rect.left + window.scrollX + 'px';
+    tooltip.classList.remove('hidden');
+  }
+
+  function hideTooltip() {
+    tooltip.classList.add('hidden');
+  }
+
+  document.addEventListener('mouseover', e => {
+    const t = e.target.closest('[data-tooltip]');
+    if (t) showTooltip(t);
+  });
+  document.addEventListener('mouseout', e => {
+    if (e.target.closest('[data-tooltip]')) hideTooltip();
+  });
+})();


### PR DESCRIPTION
## Summary
- add a lightweight tooltip widget
- attach tooltips to Agent Hub table entries
- show metric tooltips on DevOps dashboard

## Testing
- `npm test` *(fails: Cannot find module '../core/agentFlowEngine')*

------
https://chatgpt.com/codex/tasks/task_e_68662a41b9ec8323ad6225a82c314730