### PR TITLE
Add onboarding overlay

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -38,3 +38,26 @@ p {
   margin-top: 1rem;
 }
 
+.overlay-backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.6);
+  display: flex;
+  align-items: flex-end;
+  justify-content: center;
+  z-index: 50;
+}
+
+.overlay-panel {
+  background: #ffffff;
+  color: #000000;
+  padding: 1.5rem;
+  width: 100%;
+  max-width: 320px;
+  border-radius: 8px 8px 0 0;
+}
+
+.overlay-panel a {
+  color: #2563eb;
+}
+

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -1,7 +1,8 @@
-import { useRef, useState } from "react";
+import { useRef, useState, useEffect } from "react";
 import { motion, AnimatePresence, useReducedMotion } from "framer-motion";
 import { signInWithGoogle } from "./auth";
 import CanvasNetwork from "./components/CanvasNetwork";
+import OnboardingOverlay from "./components/OnboardingOverlay";
 
 const sections = {
   home: <p>Welcome to the demo app.</p>,
@@ -16,6 +17,7 @@ const sections = {
 function App() {
   const canvasRef = useRef(null);
   const [activeSection, setActiveSection] = useState("home");
+  const [showOverlay, setShowOverlay] = useState(false);
   const reduceMotion = useReducedMotion();
 
   const agents = [
@@ -23,6 +25,18 @@ function App() {
     { id: "mentor", x: 250, y: 60 },
     { id: "opportunity", x: 400, y: 200 }
   ];
+
+  useEffect(() => {
+    const completed = localStorage.getItem('demoOverlayComplete');
+    if (!completed) {
+      setShowOverlay(true);
+    }
+  }, []);
+
+  const handleOverlayDone = () => {
+    localStorage.setItem('demoOverlayComplete', '1');
+    setShowOverlay(false);
+  };
 
   const triggerPulse = id => {
     canvasRef.current?.updateActivity(id);
@@ -36,6 +50,7 @@ function App() {
 
   return (
     <div className="App">
+      {showOverlay && <OnboardingOverlay onComplete={handleOverlayDone} />}
       <h1>🚀 React Frontend Ready - No Binary Assets</h1>
 
       <nav className="space-x-2 mb-4">

--- a/frontend/src/components/OnboardingOverlay.js
+++ b/frontend/src/components/OnboardingOverlay.js
@@ -1,0 +1,56 @@
+import { useState } from 'react';
+import { motion, AnimatePresence } from 'framer-motion';
+
+export default function OnboardingOverlay({ onComplete }) {
+  const [step, setStep] = useState(0);
+
+  const steps = [
+    (
+      <div>
+        <p className="mb-2">
+          Welcome! Explore our agent logs via{' '}
+          <a href="/sample-data.json" target="_blank" rel="noopener noreferrer" className="underline text-blue-600">sample data</a>.
+        </p>
+      </div>
+    ),
+    (
+      <div>
+        <p className="mb-2">
+          Learn more about this project in the{' '}
+          <a href="/README.md" target="_blank" rel="noopener noreferrer" className="underline text-blue-600">README</a>.
+        </p>
+      </div>
+    )
+  ];
+
+  const next = () => {
+    if (step < steps.length - 1) {
+      setStep(step + 1);
+    } else {
+      onComplete();
+    }
+  };
+
+  return (
+    <AnimatePresence>
+      <motion.div
+        initial={{ opacity: 0 }}
+        animate={{ opacity: 1 }}
+        exit={{ opacity: 0 }}
+        className="overlay-backdrop"
+      >
+        <motion.div
+          initial={{ y: '100%' }}
+          animate={{ y: 0 }}
+          exit={{ y: '100%' }}
+          className="overlay-panel"
+        >
+          {steps[step]}
+          <button onClick={next} className="border px-3 py-1 rounded mt-4">
+            {step < steps.length - 1 ? 'Next' : 'Done'}
+          </button>
+        </motion.div>
+      </motion.div>
+    </AnimatePresence>
+  );
+}

--- a/public/README.md
+++ b/public/README.md
@@ -1,0 +1,204 @@
+# 🧠 Super-Intelligence
+
+[![Firebase CI/CD](https://github.com/yourusername/Super-Intelligence/actions/workflows/firebase.yml/badge.svg)](https://github.com/yourusername/Super-Intelligence/actions/workflows/firebase.yml)
+
+**Building ethical, human-centered superintelligence to empower individuals and transform global systems.**
+
+---
+
+## 🚀 Overview
+
+This repository is the foundation for an agent-driven ecosystem that powers platforms like **Opportunity Engine**—a personal transformation engine that generates scholarships, career roadmaps, and custom resources based on user goals.
+
+Our mission is to build **modular, ethical superintelligence** systems that:
+- Align with human values
+- Elevate underserved voices
+- Automate opportunity matching
+- Deliver explainable, scalable, and just outcomes
+
+---
+
+## 🛠️ Core Modules (WIP)
+
+| Agent / Module         | Purpose |
+|------------------------|---------|
+| `roadmap-agent`        | Generates personalized milestone plans for users based on goals |
+| `resume-agent`         | Creates tailored resume/LinkedIn profiles |
+| `opportunity-agent`    | Matches grants, internships, schools, and jobs |
+| `insight-agent`        | Analyzes local/global data for contextual recommendations |
+| `alignment-core`       | Implements Constitutional AI principles and safety checks |
+
+---
+
+## 🌍 Platform Example: Opportunity Engine
+
+A UI-driven system that allows users to input:
+- Name
+- Email
+- Zip Code
+- Current Standing
+- Dream Outcome
+
+And receive:
+- 📍 A step-by-step roadmap
+- 📄 A customized resume
+- 🔍 Curated opportunities
+- 🤖 Ongoing AI support via chat agents
+
+---
+
+## 📦 Tech Stack
+
+- **Frontend**: HTML/CSS, custom neural UI, React (future)
+- **Backend**: Firebase (Firestore, Functions, Auth)
+- **AI**: In-house models built on open-source frameworks (planned)
+- **Infra**: Node.js, GitHub Actions, Firebase Hosting
+
+---
+
+## 🔐 Ethical Focus
+
+This system follows ethical design guidelines including:
+- Value alignment (human-in-the-loop feedback)
+- Transparency (explainable agent logic)
+- Global accessibility (multi-lingual + inclusive)
+- Cultural adaptability
+- Long-term safety and governance
+
+Inspired by principles from:
+- UNESCO AI Ethics
+- Anthropic's Constitutional AI
+- Future of Life Institute
+
+---
+
+## 🧪 Getting Started
+
+> ⚠️ Setup instructions and sample data coming soon.
+
+### Local Development
+
+1. Install root dependencies:
+   ```bash
+   npm install
+   ```
+2. Install Cloud Functions dependencies:
+   ```bash
+   npm install --prefix functions
+   ```
+3. Install frontend dependencies:
+   ```bash
+   npm install --prefix frontend
+   ```
+4. Run tests from the repo root (requires functions dependencies):
+   ```bash
+   npm test --silent
+   ```
+5. If the Firebase emulator reports authentication errors, re-authenticate using:
+   ```bash
+   firebase login --reauth
+   ```
+
+### Launching Local Dev Environment
+
+To run Firebase Hosting locally and start the frontend app:
+
+```bash
+./start-dev.sh
+```
+If you're not logged into Firebase, it will prompt you.
+
+On CI, auth is handled via `FIREBASE_TOKEN`.
+
+### CI Deploys
+
+1. Generate a token locally using `firebase login:ci`.
+2. Store it as `FIREBASE_TOKEN` in GitHub Actions secrets or as
+   `firebase-ci-token` in Cloud Build's Secret Manager.
+3. The CI workflow injects this token so `firebase deploy` runs without
+   interactive login. If the token expires, re-run the command above.
+
+### Build Frontend for Hosting
+
+Before deploying, create a production build of the React app:
+
+```bash
+npm run build --prefix frontend
+```
+
+The command outputs static files in `frontend/build/`. Copy them to the repository's
+`public/` directory or set `hosting.public` in `firebase.json` to `frontend/build` so
+Firebase Hosting serves the build directory. Ensure these files are available before
+running:
+
+```bash
+firebase deploy
+```
+
+To push the frontend and Cloud Functions together:
+
+```bash
+npm run build --prefix frontend && firebase deploy
+```
+
+### Running `index.js` in Production
+
+When deploying the Node server (for example via App Engine) you must provide
+Firebase credentials for `firebase-admin`. Place a `serviceAccount.json` file in
+the repository root or set the `GOOGLE_APPLICATION_CREDENTIALS` environment
+variable to point at your service account file. The file name is already listed
+in `.gitignore` so your credentials won't be committed.
+
+### Debug Console
+
+Developers can review recent agent activity through `/debug.html` once
+deployed. The page authenticates with Firebase Auth and checks an email
+allowlist defined by `functions.config().debug.allowlist`. It fetches
+log entries from the `getLogs` Cloud Function and presents them in a
+filterable, auto-refreshing table grouped by agent.
+
+### AgentHub Console
+
+`/agent-hub.html` offers a registry-driven view of all agents with links
+to their docs and actions to re-run them. The registry is stored in
+`config/agents.json` and mirrored under `public/config/agents.json` for
+hosting.
+
+### Website Analysis Flow
+
+A new `runWebsiteAnalysis` Cloud Function executes the website-analysis
+flow ported from the **ai-agent-systems** repository. Trigger it with a
+POST request containing the target URL:
+
+```bash
+curl -X POST https://<REGION>-<PROJECT>.cloudfunctions.net/runWebsiteAnalysis \
+  -H "Content-Type: application/json" \
+  -d '{"url":"https://example.com"}'
+```
+
+The response contains the captured flow state and outputs for each step.
+
+## Firebase Project Info
+
+- **Project Name:** Super Intelligence  
+- **Project ID:** `super-intelligence-7b653`  
+- **Project Number:** `170923536461`
+
+---
+
+## 🙌 Contributing
+
+This project is currently in active prototyping. If you're interested in building ethical agent systems, AI for public good, or opportunity pipelines for underserved communities, [get in touch](mailto:your@email.com) or open an issue.
+
+---
+
+## 🧭 Vision
+
+We believe superintelligence should serve everyone—not just those with access or capital. This repo is our commitment to building systems that **lift people into alignment with their highest potential.**
+
+> _"Ethical superintelligence isn't about replacing human ambition—it's about scaling it with justice."_
+
+---
+
+© 2025 Csp-Ai • Licensed under MIT
+

--- a/public/sample-data.json
+++ b/public/sample-data.json
@@ -1,0 +1,51 @@
+[
+  {
+    "timestamp": "2023-01-01T00:00:00.000Z",
+    "agentName": "roadmap-agent",
+    "agentVersion": "1.0.0",
+    "userId": "sample-user",
+    "inputSummary": { "sample": true },
+    "outputSummary": { "roadmap": [] }
+  },
+  {
+    "timestamp": "2023-01-02T00:00:00.000Z",
+    "agentName": "resume-agent",
+    "agentVersion": "1.0.3",
+    "userId": "sample-user",
+    "inputSummary": {
+      "fullName": "Sample User"
+    },
+    "outputSummary": "Hi, I'm Sample User. I aim to achieve your desired goal. I bring strengths in leadership and adaptability."
+  },
+  {
+    "agent": "resume-agent",
+    "version": "v1.0.3",
+    "user": "test-user",
+    "status": "pass",
+    "alignment": {
+      "passed": true,
+      "flags": []
+    },
+    "timestamp": "2025-07-02T01:27:47.384Z",
+    "outputSummary": "Hi, I'm Test Runner. I aim to achieve land an amazing role. I bring strengths in leadership and adaptability."
+  },
+  {
+    "timestamp": "2025-07-02T01:27:47.670Z",
+    "agentName": "resume-agent",
+    "agentVersion": "v1.0.3",
+    "userId": "test-user",
+    "inputSummary": {
+      "fullName": "Test Runner",
+      "dreamOutcome": "land an amazing role"
+    },
+    "outputSummary": "Hi, I'm Test Runner. I aim to achieve land an amazing role. I bring strengths in leadership and adaptability."
+  },
+  {
+    "timestamp": "2023-01-01T00:00:00.000Z",
+    "agentName": "opportunity-agent",
+    "agentVersion": "1.0.0",
+    "userId": "sample-user",
+    "inputSummary": { "skills": ["coding"] },
+    "outputSummary": { "opportunities": [] }
+  }
+]


### PR DESCRIPTION
## Summary
- introduce multi-step `OnboardingOverlay` component
- show overlay once using `localStorage`
- style slide-in panel
- expose README and sample logs via public assets

## Testing
- `npm test --silent` *(fails: Cannot find module '../core/agentFlowEngine')*

------
https://chatgpt.com/codex/tasks/task_e_68662a425ca88323a47e86d56f082dda