### PR TITLE
Add GitHub star banner and demo scripts

### DIFF
--- a/public/demo-data.json
+++ b/public/demo-data.json
@@ -1,0 +1,6 @@
+{
+  "users": [
+    {"name": "Ada", "skills": ["AI", "ML"]},
+    {"name": "Grace", "skills": ["Networking", "Security"]}
+  ]
+}

--- a/public/demo.js
+++ b/public/demo.js
@@ -1,0 +1,22 @@
+async function loadDemoData() {
+  try {
+    const resp = await fetch('demo-data.json');
+    const data = await resp.json();
+    console.log('Loaded demo data:', data);
+    const statusEl = document.getElementById('status');
+    statusEl.textContent = `Loaded ${data.users.length} demo users.`;
+  } catch (err) {
+    console.error('Failed to load demo data', err);
+  }
+}
+
+function runTrainingSimulation() {
+  const statusEl = document.getElementById('status');
+  statusEl.textContent = 'Running simulation...';
+  setTimeout(() => {
+    statusEl.textContent = 'Simulation complete.';
+  }, 1000);
+}
+
+document.getElementById('demoBtn').addEventListener('click', loadDemoData);
+document.getElementById('trainBtn').addEventListener('click', runTrainingSimulation);

--- a/public/github-stats.js
+++ b/public/github-stats.js
@@ -1,0 +1,14 @@
+async function updateStarCount() {
+  try {
+    const resp = await fetch('https://api.github.com/repos/Csp-Ai/Super-Intelligence');
+    const data = await resp.json();
+    const stars = data.stargazers_count;
+    const el = document.getElementById('githubStar');
+    if (el) {
+      el.innerHTML = `Star us on GitHub ⭐ ${stars}`;
+    }
+  } catch (err) {
+    console.error('Failed to fetch GitHub stats', err);
+  }
+}
+updateStarCount();

--- a/public/index.html
+++ b/public/index.html
@@ -31,10 +31,17 @@
     <input id="dream" class="border p-2 w-full mb-2" placeholder="Dream outcome" />
     <input id="skills" class="border p-2 w-full mb-4" placeholder="Skills (comma separated)" />
     <button id="signupBtn" class="bg-blue-600 text-white px-4 py-2 rounded w-full mb-2">Sign Up</button>
-    <button id="googleBtn" class="bg-red-600 text-white px-4 py-2 rounded w-full">Sign Up with Google</button>
+    <button id="googleBtn" class="bg-red-600 text-white px-4 py-2 rounded w-full mb-2">Sign Up with Google</button>
+    <button id="demoBtn" class="bg-gray-200 px-4 py-2 rounded w-full mb-2">Load Demo Data</button>
+    <button id="trainBtn" class="bg-gray-200 px-4 py-2 rounded w-full">Run Training Simulation</button>
     <p id="status" class="text-sm mt-2"></p>
   </div>
+  <footer class="text-center mt-6 text-sm" id="starFooter">
+    <a href="https://github.com/Csp-Ai/Super-Intelligence" target="_blank" id="githubStar" class="underline">Star us on GitHub</a>
+  </footer>
   <script src="onboarding.js"></script>
+  <script src="demo.js"></script>
+  <script src="github-stats.js"></script>
   <label class="fixed bottom-2 right-2 bg-gray-200 p-1 rounded text-xs"><input type="checkbox" id="reduceMotionToggle"> Reduce Motion</label>
   <script src="reduce-motion.js"></script>
 </body>


### PR DESCRIPTION
## Summary
- promote the repository with a GitHub star footer banner
- add demo dataset loader and training simulation buttons
- fetch GitHub star count using the GitHub API

## Testing
- `npm test --silent` *(fails: Cannot find module 'ajv')*

------
https://chatgpt.com/codex/tasks/task_e_68662a4358dc8323b9faa878fe507057