### PR TITLE
Add setup script with offline fallback

### DIFF
--- a/ci.yml
+++ b/ci.yml
@@ -1,0 +1,16 @@
+# GitHub Actions snippet to run setup.sh
+steps:
+  - uses: actions/checkout@v3
+
+  - name: Grant execute permission for setup script
+    run: chmod +x setup.sh
+
+  - name: Run setup
+    run: ./setup.sh
+
+  # Example build and test steps
+  - name: Build
+    run: npm run build
+
+  - name: Test
+    run: npm test --silent

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,75 @@
+#!/bin/bash
+set -e
+
+log() {
+  echo "[setup] $(date '+%Y-%m-%d %H:%M:%S') - $1"
+}
+
+APT_PACKAGES=(git python3 python3-pip nodejs npm)
+UPDATE_DONE=0
+
+install_pkg() {
+  local pkg="$1"
+  if dpkg -s "$pkg" >/dev/null 2>&1; then
+    log "$pkg already installed"
+  else
+    if [ "$UPDATE_DONE" -eq 0 ]; then
+      log "Running apt-get update"
+      if apt-get update -y >/dev/null 2>&1; then
+        log "apt-get update completed"
+      else
+        log "apt-get update failed (offline?). Proceeding with cache"
+      fi
+      UPDATE_DONE=1
+    fi
+    log "Installing $pkg"
+    if apt-get install -y "$pkg" >/dev/null 2>&1; then
+      log "$pkg installed"
+    else
+      log "Failed to install $pkg"
+    fi
+  fi
+}
+
+for pkg in "${APT_PACKAGES[@]}"; do
+  install_pkg "$pkg"
+done
+
+# Python dependencies
+if command -v pip3 >/dev/null 2>&1; then
+  if [ -f requirements.txt ]; then
+    if ping -c1 pypi.org >/dev/null 2>&1; then
+      log "Installing Python requirements"
+      pip3 install -r requirements.txt >/dev/null 2>&1 || log "pip install failed"
+    elif [ -d vendor ]; then
+      log "Offline: installing Python deps from vendor/"
+      pip3 install --no-index --find-links vendor -r requirements.txt >/dev/null 2>&1 || log "pip vendor install failed"
+    else
+      log "No network and no vendor directory; skipping Python deps"
+    fi
+  else
+    log "No requirements.txt found"
+  fi
+else
+  log "pip3 not available"
+fi
+
+# Node dependencies
+if command -v npm >/dev/null 2>&1; then
+  if [ -f package.json ]; then
+    log "Installing root npm packages"
+    npm install >/dev/null 2>&1 || log "npm install failed"
+  fi
+  if [ -f functions/package.json ]; then
+    log "Installing functions npm packages"
+    npm install --prefix functions >/dev/null 2>&1 || log "functions npm install failed"
+  fi
+  if [ -f frontend/package.json ]; then
+    log "Installing frontend npm packages"
+    npm install --prefix frontend >/dev/null 2>&1 || log "frontend npm install failed"
+  fi
+else
+  log "npm not available"
+fi
+
+log "Setup complete"


### PR DESCRIPTION
## Summary
- add `setup.sh` to install system and node/python dependencies
- include fallback to local `vendor/` folder when offline
- provide simple `ci.yml` snippet demonstrating usage

## Testing
- `./setup.sh`
- `npm test --silent` *(fails: Cannot find module '../core/agentFlowEngine')*

------
https://chatgpt.com/codex/tasks/task_e_68662ed15df4832388627e6252557e1c