### PR TITLE
Add Firebase config validation workflow

### DIFF
--- a/.github/workflows/firebase-validate.yml
+++ b/.github/workflows/firebase-validate.yml
@@ -1,0 +1,30 @@
+name: Firebase Config Validation
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Grant execute permission for setup script
+        run: chmod +x setup.sh
+      - name: Run setup script
+        run: ./setup.sh
+      - name: Run npm tests
+        run: npm test --silent
+
+  firebase-validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Setup Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18
+      - name: Validate Firebase configuration
+        run: node scripts/checkFirebaseTargets.js


### PR DESCRIPTION
## Summary
- verify Firebase hosting config with updated checkFirebaseTargets.js
- run new firebase-validate job alongside tests

## Testing
- `npm install`
- `npm test --silent` *(fails: Decoding Firebase ID token failed)*
- `node scripts/checkFirebaseTargets.js`

------
https://chatgpt.com/codex/tasks/task_e_68663396cb1c8323af61fab2e82a6f4f