### PR TITLE
Add analytics-agent

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,6 +7,14 @@
 - 🔗 [View source](https://github.com/Csp-Ai/Super-Intelligence/blob/main/functions/agents/alignment-core.js)
 - 🧠 Description: TBD
 
+### analytics-agent
+- 📁 Path: `functions/agents/analytics-agent.js`
+- 🏷️ Tags: analytics
+- 📅 Last updated: unknown
+- 🔗 [View source](https://github.com/Csp-Ai/Super-Intelligence/blob/main/functions/agents/analytics-agent.js)
+- 🧠 Description: Logs frontend interaction metrics
+- ▶️ Command: `firebase functions:call analyticsAgent --data '{"eventName":"test","userId":"123"}'`
+
 ### anomaly-agent
 - 📁 Path: `functions/agents/anomalyAgent.js`
 - 🏷️ Tags: monitor

--- a/config/agents.json
+++ b/config/agents.json
@@ -194,5 +194,17 @@
     "sourcePath": "functions/agents/board-agent-hybrid.js",
     "tags": ["analytics"],
     "lifecycle": "stable"
+  },
+  "analytics-agent": {
+    "name": "analytics-agent",
+    "description": "Logs frontend interaction metrics",
+    "version": "v1.0.0",
+    "lastRunStatus": "unknown",
+    "agentType": "analytics",
+    "enabled": true,
+    "docsUrl": "../functions/agents/analytics-agent.js",
+    "sourcePath": "functions/agents/analytics-agent.js",
+    "tags": ["analytics"],
+    "lifecycle": "beta"
   }
 }

--- a/functions/agents/analytics-agent.js
+++ b/functions/agents/analytics-agent.js
@@ -1,0 +1,39 @@
+const admin = require('firebase-admin');
+const functions = require('firebase-functions/v1');
+
+/**
+ * Store UI interaction analytics.
+ * @param {Object} payload
+ * @param {string} payload.eventName - Event identifier
+ * @param {string} payload.userId - UID or email
+ * @param {string} [payload.timestamp] - ISO timestamp
+ * @returns {Promise<{status:string}>}
+ */
+async function logInteraction(payload = {}) {
+  const { eventName, userId, timestamp = new Date().toISOString() } = payload;
+  if (!eventName || !userId) {
+    throw new Error('eventName and userId required');
+  }
+  if (process.env.LOCAL_AGENT_RUN) {
+    return { status: 'skipped' };
+  }
+  const db = admin.firestore();
+  await db.collection('analytics')
+    .doc(userId)
+    .collection(eventName)
+    .add({ ...payload, timestamp });
+  return { status: 'logged' };
+}
+
+exports.analyticsAgent = functions.https.onCall(async (data, context) => {
+  const userId = data.userId || (context.auth && context.auth.uid);
+  const eventName = data.eventName;
+  const timestamp = data.timestamp || new Date().toISOString();
+  if (!userId || !eventName) {
+    throw new functions.https.HttpsError('invalid-argument', 'userId and eventName required');
+  }
+  await logInteraction({ ...data, userId, eventName, timestamp });
+  return { status: 'ok' };
+});
+
+module.exports = { logInteraction };

--- a/functions/index.js
+++ b/functions/index.js
@@ -81,6 +81,7 @@ exports.translateText = require('./utils/translate').translateText;
 exports.translateOutput = require('./utils/translate').translateOutput;
 
 exports.trainAgent = require('./trainAgent').trainAgent;
+exports.analyticsAgent = require('./agents/analytics-agent').analyticsAgent;
 
 exports.runWebsiteAnalysis = require('./runWebsiteAnalysis').runWebsiteAnalysis;
 


### PR DESCRIPTION
## Summary
- register `analytics-agent` in config
- log frontend interaction metrics via `analytics-agent` Cloud Function
- document new agent in AGENTS.md
- export function in `functions/index.js`

## Testing
- `npm install`
- `npm --prefix functions install`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6866339b74e08323b4d2a5c4dff00737