### PR TITLE
Add Vite env example files

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,11 +90,18 @@ Inspired by principles from:
    ```bash
    npm install --prefix frontend
    ```
-4. Run tests from the repo root (requires functions dependencies):
+4. Create environment files in `frontend/`:
+   ```bash
+   cp frontend/.env frontend/.env.local
+   cp frontend/.env.production frontend/.env.production.local
+   ```
+   Edit these files to include your Firebase config such as
+   `VITE_FIREBASE_API_KEY`.
+5. Run tests from the repo root (requires functions dependencies):
    ```bash
    npm test --silent
    ```
-5. If the Firebase emulator reports authentication errors, re-authenticate using:
+6. If the Firebase emulator reports authentication errors, re-authenticate using:
    ```bash
    firebase login --reauth
    ```

--- a/frontend/.env
+++ b/frontend/.env
@@ -1,0 +1,8 @@
+# Sample local environment variables for Vite
+VITE_FIREBASE_API_KEY="your-local-api-key"
+VITE_FIREBASE_AUTH_DOMAIN="your-local-auth-domain"
+VITE_FIREBASE_PROJECT_ID="your-local-project-id"
+VITE_FIREBASE_STORAGE_BUCKET="your-local-storage-bucket"
+VITE_FIREBASE_MESSAGING_SENDER_ID="your-local-messaging-sender-id"
+VITE_FIREBASE_APP_ID="your-local-app-id"
+VITE_FIREBASE_MEASUREMENT_ID="your-local-measurement-id"

--- a/frontend/.env.production
+++ b/frontend/.env.production
@@ -1,0 +1,8 @@
+# Sample production environment variables for Vite
+VITE_FIREBASE_API_KEY="your-prod-api-key"
+VITE_FIREBASE_AUTH_DOMAIN="your-prod-auth-domain"
+VITE_FIREBASE_PROJECT_ID="your-prod-project-id"
+VITE_FIREBASE_STORAGE_BUCKET="your-prod-storage-bucket"
+VITE_FIREBASE_MESSAGING_SENDER_ID="your-prod-messaging-sender-id"
+VITE_FIREBASE_APP_ID="your-prod-app-id"
+VITE_FIREBASE_MEASUREMENT_ID="your-prod-measurement-id"

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -1,10 +1,16 @@
-import { defineConfig } from 'vite'
+import { defineConfig, loadEnv } from 'vite'
 import react from '@vitejs/plugin-react'
 
-export default defineConfig({
-  plugins: [react()],
-  esbuild: {
-    loader: 'jsx',
-    include: /src\/.*\.js$/
+export default defineConfig(({ mode }) => {
+  const env = loadEnv(mode, process.cwd())
+  return {
+    plugins: [react()],
+    define: {
+      'process.env': { ...process.env, ...env }
+    },
+    esbuild: {
+      loader: 'jsx',
+      include: /src\/.*\.js$/
+    }
   }
 })


### PR DESCRIPTION
## Summary
- add example `.env` and `.env.production` in the frontend
- load env vars in `vite.config.js`
- document how to use the env files in README

## Testing
- `npm install`
- `npm --prefix functions install`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68663f5bfce88323a82983524e17c628