### PR TITLE
Move ajv to devDependencies

### DIFF
--- a/functions/package-lock.json
+++ b/functions/package-lock.json
@@ -6,11 +6,13 @@
     "": {
       "name": "functions",
       "dependencies": {
-        "ajv": "^8.17.1",
         "firebase-admin": "^11.0.0",
         "firebase-functions": "^6.3.2",
         "super-intelligence-app": "file:..",
         "ws": "^8.13.0"
+      },
+      "devDependencies": {
+        "ajv": "^8.17.1"
       },
       "engines": {
         "node": "18"
@@ -20,16 +22,16 @@
       "name": "super-intelligence-app",
       "version": "1.0.0",
       "dependencies": {
-        "ajv": "^8.12.0",
         "eventsource": "^4.0.0",
         "express": "^4.18.2",
-        "firebase": "^9.6.10",
+        "firebase": "^11.10.0",
         "firebase-admin": "^11.0.0",
         "firebase-functions": "^3.24.1",
         "jsdom": "^26.1.0",
         "ws": "^8.13.0"
       },
       "devDependencies": {
+        "ajv": "^8.17.1",
         "concurrently": "^9.2.0",
         "firebase-tools": "^13.0.0"
       },
@@ -661,6 +663,7 @@
       "version": "8.17.1",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
@@ -1344,6 +1347,7 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/fast-levenshtein": {
@@ -1364,6 +1368,7 @@
       "version": "3.0.6",
       "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.0.6.tgz",
       "integrity": "sha512-Atfo14OibSv5wAp4VWNsFYE1AchQRTv9cBGWET4pZWHzYshFSS9NQI6I57rdKn9croWVMbYFbLhJ+yJvmZIIHw==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -2039,6 +2044,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/jsonwebtoken": {
@@ -2767,6 +2773,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
       "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"

--- a/functions/package.json
+++ b/functions/package.json
@@ -5,7 +5,6 @@
     "node": "18"
   },
   "dependencies": {
-    "ajv": "^8.17.1",
     "firebase-admin": "^11.0.0",
     "firebase-functions": "^6.3.2",
     "super-intelligence-app": "file:..",
@@ -13,5 +12,8 @@
   },
   "scripts": {
     "test": "node testRoadmapAgent.js && node testResumeAgent.js && node testOpportunityAgent.js && node testOnboardingFlow.js && node testInsightsAgent.js && node testAnomalyAgent.js && node testTrendsAgent.js && node testSummarizeReplayLogs.js && node testLifecycleFlow.js && node testFeedbackAction.js"
+  },
+  "devDependencies": {
+    "ajv": "^8.17.1"
   }
 }


### PR DESCRIPTION
## Summary
- move `ajv` from dependencies to devDependencies for Cloud Functions
- update the lock file via `npm install`

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68664a9b1d388323b25ab9ba404d6b97