### PR TITLE
Fix Firebase target mismatch

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -9,12 +9,29 @@
     },
     "source": "frontend/dist"
   },
-  "hosting": {
-    "source": "frontend/dist",
-    "rewrites": [
-      { "source": "**", "destination": "/index.html" }
-    ]
-  },
+  "hosting": [
+    {
+      "target": "staging",
+      "source": "frontend/dist",
+      "rewrites": [
+        { "source": "**", "destination": "/index.html" }
+      ]
+    },
+    {
+      "target": "production",
+      "source": "frontend/dist",
+      "rewrites": [
+        { "source": "**", "destination": "/index.html" }
+      ]
+    },
+    {
+      "target": "hybrid",
+      "source": "frontend/dist",
+      "rewrites": [
+        { "source": "**", "destination": "/index.html" }
+      ]
+    }
+  ],
   "emulators": {
     "auth": {
       "port": 9099


### PR DESCRIPTION
## Summary
- add staging, production and hybrid hosting configs
- keep checkFirebaseTargets script in sync

## Testing
- `node scripts/checkFirebaseTargets.js`
- `npm test --silent` *(fails: Cannot find module 'ajv')*


------
https://chatgpt.com/codex/tasks/task_e_686652499d2483238a9c532efa7dca90