### PR TITLE
Fix preview workflow

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -16,6 +16,8 @@ jobs:
           node-version: 18
       - name: Install dependencies
         run: npm install
+      - name: Install frontend dependencies
+        run: npm install --prefix frontend
       - name: Install Ajv
         run: npm install ajv --save-dev
       - name: Install Firebase CLI


### PR DESCRIPTION
## Summary
- add frontend dependency step so vite installs during deploy-preview

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6866522d358c8323b9de8ea7e5a536f2