### PR TITLE
Add TrendsPanel component

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -8,6 +8,7 @@ import CanvasNetwork from "./components/CanvasNetwork";
 import OnboardingOverlay from "./components/OnboardingOverlay";
 import SectionNav from "./components/SectionNav";
 import AgentCard from "./components/AgentCard";
+import TrendsPanel from "./components/TrendsPanel";
 import { DashboardDataProvider } from "./context/DashboardDataContext";
 
 const sections = {
@@ -143,6 +144,8 @@ function App() {
           );
         })}
       </div>
+
+      <TrendsPanel />
 
       <button onClick={() => triggerPulse("core")}>Trigger Core Pulse</button>
       <CanvasNetwork ref={canvasRef} agents={agents} width={500} height={300} />

--- a/frontend/src/components/TrendsPanel.jsx
+++ b/frontend/src/components/TrendsPanel.jsx
@@ -1,0 +1,57 @@
+import React, { useEffect, useState } from 'react';
+import { getFirestore, doc, getDoc } from 'firebase/firestore';
+import { app, auth } from '../firebase';
+import MetricCard from './MetricCard';
+
+const TrendsPanel = () => {
+  const [trends, setTrends] = useState(null);
+
+  useEffect(() => {
+    const fetchTrends = async () => {
+      try {
+        const db = getFirestore(app);
+        let snap;
+        const uid = auth.currentUser?.uid;
+        if (uid) {
+          const userDoc = doc(db, 'users', uid, 'trends', 'summary');
+          snap = await getDoc(userDoc);
+          if (snap.exists()) {
+            setTrends(snap.data());
+            return;
+          }
+        }
+        const globalDoc = doc(db, 'globalTrends', 'forecast');
+        snap = await getDoc(globalDoc);
+        if (snap.exists()) setTrends(snap.data());
+      } catch (err) {
+        console.error('Failed to fetch trends', err);
+      }
+    };
+
+    fetchTrends();
+  }, []);
+
+  if (!trends) return null;
+
+  const metrics = trends.metrics || {};
+  const forecast = trends.forecast || {};
+
+  return (
+    <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4 mb-4">
+      {Object.entries(metrics).map(([agent, m]) => (
+        <div key={agent} className="p-4 bg-white/10 rounded shadow">
+          <h3 className="font-semibold mb-2 capitalize">{agent.replace(/-agent$/, '')}</h3>
+          <div className="grid grid-cols-2 gap-2 text-sm">
+            <MetricCard label="Total Runs" value={m.totalRuns || 0} />
+            <MetricCard label="Success Rate" value={`${Math.round((m.successRate || 0) * 100)}%`} />
+            {forecast[agent] && (
+              <MetricCard label="Next Run" value={new Date(forecast[agent]).toLocaleDateString()} />
+            )}
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+};
+
+export default TrendsPanel;


### PR DESCRIPTION
## Summary
- fetch trend data from Firestore
- show runs and success metrics in `TrendsPanel`
- add `TrendsPanel` to the dashboard

## Testing
- `npm install`
- `npm --prefix functions install`
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_68665829398c83238911bbb174db2cbb