### PR TITLE
Add anomaly panel with lifecycle state

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -8,6 +8,7 @@ import CanvasNetwork from "./components/CanvasNetwork";
 import OnboardingOverlay from "./components/OnboardingOverlay";
 import SectionNav from "./components/SectionNav";
 import AgentCard from "./components/AgentCard";
+import AnomalyPanel from "./components/AnomalyPanel";
 import { DashboardDataProvider } from "./context/DashboardDataContext";
 
 const sections = {
@@ -35,6 +36,7 @@ function App() {
     defaultAgents.map(a => ({ ...a, activity: 0, connections: 0 }))
   );
   const [registry, setRegistry] = useState([]);
+  const [showAnomaliesFor, setShowAnomaliesFor] = useState(null);
 
   useEffect(() => {
     fetch('/config/agents.json')
@@ -137,12 +139,26 @@ function App() {
               agentName={reg.name}
               metrics={metrics}
               status={reg.lastRunStatus}
+              state={live.currentState}
               anomalyScore={live.anomalyScore}
               onTrain={() => trainAgent(reg.name)}
+              onViewAnomalies={() => setShowAnomaliesFor(reg.name)}
             />
           );
         })}
       </div>
+
+      {showAnomaliesFor && (
+        <div>
+          <AnomalyPanel agentId={showAnomaliesFor} />
+          <button
+            onClick={() => setShowAnomaliesFor(null)}
+            className="border px-2 py-1 rounded text-sm"
+          >
+            Close
+          </button>
+        </div>
+      )}
 
       <button onClick={() => triggerPulse("core")}>Trigger Core Pulse</button>
       <CanvasNetwork ref={canvasRef} agents={agents} width={500} height={300} />

--- a/frontend/src/components/AgentCard.jsx
+++ b/frontend/src/components/AgentCard.jsx
@@ -1,7 +1,14 @@
 import React from 'react';
 import { motion } from 'framer-motion';
 
-const AgentCard = ({ agentName, metrics = {}, status, anomalyScore, onTrain }) => {
+const stateColors = {
+  online: 'bg-green-500',
+  offline: 'bg-red-500',
+  'under-review': 'bg-yellow-500',
+  deprecated: 'bg-gray-500'
+};
+
+const AgentCard = ({ agentName, metrics = {}, status, state, anomalyScore, onTrain, onViewAnomalies }) => {
   return (
     <motion.div
       whileHover={{ scale: 1.05 }}
@@ -9,6 +16,15 @@ const AgentCard = ({ agentName, metrics = {}, status, anomalyScore, onTrain }) =
     >
       <h3 className="font-semibold text-lg mb-2">{agentName}</h3>
       <p className="text-sm mb-1">Status: {status}</p>
+      {state && (
+        <p className="text-sm mb-1 flex items-center">
+          State:
+          <span
+            className={`ml-1 w-2 h-2 rounded-full ${stateColors[state] || 'bg-gray-300'}`}
+          ></span>
+          <span className="ml-1">{state}</span>
+        </p>
+      )}
       {anomalyScore !== undefined && (
         <p className="text-sm mb-2">Anomaly Score: {anomalyScore}</p>
       )}
@@ -19,14 +35,24 @@ const AgentCard = ({ agentName, metrics = {}, status, anomalyScore, onTrain }) =
           </li>
         ))}
       </ul>
-      {onTrain && (
-        <button
-          onClick={onTrain}
-          className="mt-1 border px-2 py-1 rounded text-sm"
-        >
-          Train
-        </button>
-      )}
+      <div className="flex space-x-2">
+        {onTrain && (
+          <button
+            onClick={onTrain}
+            className="mt-1 border px-2 py-1 rounded text-sm"
+          >
+            Train
+          </button>
+        )}
+        {onViewAnomalies && (
+          <button
+            onClick={onViewAnomalies}
+            className="mt-1 border px-2 py-1 rounded text-sm"
+          >
+            View Anomalies
+          </button>
+        )}
+      </div>
     </motion.div>
   );
 };

--- a/frontend/src/components/AnomalyPanel.jsx
+++ b/frontend/src/components/AnomalyPanel.jsx
@@ -1,0 +1,37 @@
+import React, { useEffect, useState } from 'react';
+import { getFirestore, collection, query, orderBy, limit, where, onSnapshot } from 'firebase/firestore';
+import { app } from '../firebase';
+
+export default function AnomalyPanel({ agentId }) {
+  const [events, setEvents] = useState([]);
+
+  useEffect(() => {
+    const db = getFirestore(app);
+    let q = collection(db, 'anomalies');
+    if (agentId) {
+      q = query(q, where('agent', '==', agentId));
+    }
+    q = query(q, orderBy('timestamp', 'desc'), limit(10));
+    const unsub = onSnapshot(q, snap => {
+      const items = [];
+      snap.forEach(doc => items.push(doc.data()));
+      setEvents(items);
+    });
+    return () => unsub();
+  }, [agentId]);
+
+  return (
+    <div className="anomaly-panel bg-white/10 backdrop-blur p-3 rounded shadow mb-4">
+      <h4 className="font-semibold mb-2">Recent Anomalies {agentId && `for ${agentId}`}</h4>
+      <ul className="text-sm space-y-1">
+        {events.map((e, idx) => (
+          <li key={idx} className="flex justify-between">
+            <span>{e.agent} - {e.type}</span>
+            <span className="text-xs text-gray-400">{e.timestamp}</span>
+          </li>
+        ))}
+        {events.length === 0 && <li>No anomalies found.</li>}
+      </ul>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- show color-coded lifecycle state in AgentCard
- add AnomalyPanel component to list recent anomalies
- connect AgentCard to panel with "View Anomalies" button

## Testing
- `npm test --silent` *(fails: Decoding Firebase ID token failed)*

------
https://chatgpt.com/codex/tasks/task_e_6866582c179c832383df71463829572c