### PR TITLE
Add lifecycle timeline modal

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -10,6 +10,7 @@ import SectionNav from "./components/SectionNav";
 import AgentCard from "./components/AgentCard";
 import AnomalyPanel from "./components/AnomalyPanel";
 import TrendsPanel from "./components/TrendsPanel";
+import LifecycleTimeline from "./components/LifecycleTimeline";
 import { DashboardDataProvider } from "./context/DashboardDataContext";
 
 const sections = {
@@ -38,6 +39,7 @@ function App() {
   );
   const [registry, setRegistry] = useState([]);
   const [showAnomaliesFor, setShowAnomaliesFor] = useState(null);
+  const [showLifecycleFor, setShowLifecycleFor] = useState(null);
 
   useEffect(() => {
     fetch('/config/agents.json')
@@ -144,6 +146,7 @@ function App() {
                 anomalyScore={live.anomalyScore}
                 onTrain={() => trainAgent(reg.name)}
                 onViewAnomalies={() => setShowAnomaliesFor(reg.name)}
+                onStatusClick={() => setShowLifecycleFor(reg.name)}
               />
             );
           })}
@@ -158,6 +161,20 @@ function App() {
             >
               Close
             </button>
+          </div>
+        )}
+
+        {showLifecycleFor && (
+          <div className="overlay-backdrop">
+            <div className="overlay-panel">
+              <LifecycleTimeline agentId={showLifecycleFor} />
+              <button
+                onClick={() => setShowLifecycleFor(null)}
+                className="border px-2 py-1 rounded text-sm mt-2"
+              >
+                Close
+              </button>
+            </div>
           </div>
         )}
 

--- a/frontend/src/components/AgentCard.jsx
+++ b/frontend/src/components/AgentCard.jsx
@@ -8,14 +8,22 @@ const stateColors = {
   deprecated: 'bg-gray-500'
 };
 
-const AgentCard = ({ agentName, metrics = {}, status, state, anomalyScore, onTrain, onViewAnomalies }) => {
+const AgentCard = ({ agentName, metrics = {}, status, state, anomalyScore, onTrain, onViewAnomalies, onStatusClick }) => {
   return (
     <motion.div
       whileHover={{ scale: 1.05 }}
       className="p-4 rounded shadow-md bg-white/10 backdrop-blur hover:shadow-lg transition-shadow"
     >
       <h3 className="font-semibold text-lg mb-2">{agentName}</h3>
-      <p className="text-sm mb-1">Status: {status}</p>
+      <p className="text-sm mb-1">
+        Status:
+        <span
+          onClick={onStatusClick}
+          className="ml-1 underline cursor-pointer"
+        >
+          {status}
+        </span>
+      </p>
       {state && (
         <p className="text-sm mb-1 flex items-center">
           State:

--- a/frontend/src/components/LifecycleTimeline.jsx
+++ b/frontend/src/components/LifecycleTimeline.jsx
@@ -1,0 +1,52 @@
+import React, { useEffect, useState } from 'react';
+import { getFirestore, collection, getDocs, query, orderBy } from 'firebase/firestore';
+import { app } from '../firebase';
+
+const stateStyles = {
+  online: 'text-green-400',
+  offline: 'text-red-400',
+  'under-review': 'text-yellow-400'
+};
+
+export default function LifecycleTimeline({ agentId }) {
+  const [events, setEvents] = useState([]);
+
+  useEffect(() => {
+    if (!agentId) return;
+    const fetchData = async () => {
+      try {
+        const db = getFirestore(app);
+        const q = query(
+          collection(db, 'agents', agentId, 'lifecycle'),
+          orderBy('timestamp', 'asc')
+        );
+        const snap = await getDocs(q);
+        const list = snap.docs.map(doc => ({ state: doc.id, ...doc.data() }));
+        setEvents(list);
+      } catch (err) {
+        console.error('Failed to fetch lifecycle', err);
+      }
+    };
+    fetchData();
+  }, [agentId]);
+
+  if (!events.length) {
+    return <p>No lifecycle data.</p>;
+  }
+
+  return (
+    <div>
+      <h4 className="font-semibold mb-2">Lifecycle Timeline</h4>
+      <ul className="space-y-2 text-sm">
+        {events.map(evt => (
+          <li key={evt.state} className="flex justify-between items-center">
+            <span className={stateStyles[evt.state] || ''}>{evt.state}</span>
+            <span className="text-xs text-gray-400">
+              {evt.timestamp ? new Date(evt.timestamp).toLocaleString() : ''}
+            </span>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- fetch agent lifecycle states from Firestore
- show lifecycle timeline modal when clicking status in `AgentCard`
- style lifecycle states

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68665a5bf1548323a6ff325270f9c53b