### PR TITLE
Add guidance panels

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -12,6 +12,9 @@ import AnomalyPanel from "./components/AnomalyPanel";
 import TrendsPanel from "./components/TrendsPanel";
 import LifecycleTimeline from "./components/LifecycleTimeline";
 import InsightsChart from "./components/InsightsChart";
+import BoardPanel from "./components/BoardPanel";
+import MentorPanel from "./components/MentorPanel";
+import GuardianPanel from "./components/GuardianPanel";
 import { DashboardDataProvider } from "./context/DashboardDataContext";
 
 const sections = {
@@ -28,6 +31,7 @@ function App() {
   const canvasRef = useRef(null);
   const [activeSection, setActiveSection] = useState("home");
   const [showOverlay, setShowOverlay] = useState(false);
+  const [showGuidance, setShowGuidance] = useState(false);
   const reduceMotion = useReducedMotion();
 
   const layoutAgents = ids => {
@@ -196,6 +200,22 @@ function App() {
 
         <TrendsPanel />
         <InsightsChart />
+
+        <div className="bg-white/10 p-4 rounded shadow mb-4">
+          <button
+            onClick={() => setShowGuidance(!showGuidance)}
+            className="font-semibold mb-2"
+          >
+            Agent Guidance {showGuidance ? '▲' : '▼'}
+          </button>
+          {showGuidance && (
+            <div className="mt-2 space-y-4">
+              <BoardPanel />
+              <MentorPanel />
+              <GuardianPanel />
+            </div>
+          )}
+        </div>
 
         <button onClick={() => triggerPulse("core")}>Trigger Core Pulse</button>
         <CanvasNetwork ref={canvasRef} agents={agents} width={500} height={300} />

--- a/frontend/src/components/BoardPanel.jsx
+++ b/frontend/src/components/BoardPanel.jsx
@@ -1,0 +1,42 @@
+import React, { useEffect, useState } from 'react';
+import { getFirestore, collection, query, where, orderBy, limit, onSnapshot } from 'firebase/firestore';
+import { app } from '../firebase';
+
+export default function BoardPanel() {
+  const [summaries, setSummaries] = useState([]);
+
+  useEffect(() => {
+    const db = getFirestore(app);
+    const q = query(
+      collection(db, 'logs'),
+      where('agentName', '==', 'board-agent'),
+      orderBy('timestamp', 'desc'),
+      limit(5)
+    );
+    const unsub = onSnapshot(q, snap => {
+      const list = [];
+      snap.forEach(doc => {
+        const data = doc.data();
+        const summary = data.outputSummary?.summary || data.outputSummary || '';
+        list.push({ summary, timestamp: data.timestamp });
+      });
+      setSummaries(list);
+    });
+    return () => unsub();
+  }, []);
+
+  return (
+    <div className="bg-white/10 p-4 rounded shadow mb-4">
+      <h3 className="font-semibold mb-2">Board Summaries</h3>
+      <ul className="space-y-1 text-sm">
+        {summaries.map((s, idx) => (
+          <li key={idx} className="flex justify-between">
+            <span>{typeof s.summary === 'string' ? s.summary : JSON.stringify(s.summary)}</span>
+            <span className="text-xs text-gray-400">{s.timestamp ? new Date(s.timestamp).toLocaleString() : ''}</span>
+          </li>
+        ))}
+        {summaries.length === 0 && <li>No summaries found.</li>}
+      </ul>
+    </div>
+  );
+}

--- a/frontend/src/components/GuardianPanel.jsx
+++ b/frontend/src/components/GuardianPanel.jsx
@@ -1,0 +1,50 @@
+import React, { useEffect, useState } from 'react';
+import { getFirestore, collection, query, where, orderBy, limit, onSnapshot } from 'firebase/firestore';
+import { app } from '../firebase';
+
+export default function GuardianPanel() {
+  const [logs, setLogs] = useState([]);
+
+  useEffect(() => {
+    const db = getFirestore(app);
+    const q = query(
+      collection(db, 'logs'),
+      where('agentName', '==', 'guardian-agent'),
+      orderBy('timestamp', 'desc'),
+      limit(5)
+    );
+    const unsub = onSnapshot(q, snap => {
+      const items = [];
+      snap.forEach(doc => {
+        const data = doc.data();
+        items.push({
+          message: data.outputSummary?.message || data.outputSummary || data.message || '',
+          flags: data.alignment?.flags || data.flags || [],
+          timestamp: data.timestamp
+        });
+      });
+      setLogs(items);
+    });
+    return () => unsub();
+  }, []);
+
+  return (
+    <div className="bg-white/10 p-4 rounded shadow mb-4">
+      <h3 className="font-semibold mb-2">Compliance Logs</h3>
+      <ul className="space-y-1 text-sm">
+        {logs.map((log, idx) => (
+          <li key={idx} className="flex flex-col">
+            <span className="flex justify-between">
+              <span>{typeof log.message === 'string' ? log.message : JSON.stringify(log.message)}</span>
+              <span className="text-xs text-gray-400">{log.timestamp ? new Date(log.timestamp).toLocaleString() : ''}</span>
+            </span>
+            {log.flags.length > 0 && (
+              <span className="text-xs text-red-400">Flags: {log.flags.join(', ')}</span>
+            )}
+          </li>
+        ))}
+        {logs.length === 0 && <li>No compliance logs found.</li>}
+      </ul>
+    </div>
+  );
+}

--- a/frontend/src/components/MentorPanel.jsx
+++ b/frontend/src/components/MentorPanel.jsx
@@ -1,0 +1,45 @@
+import React, { useEffect, useState } from 'react';
+import { getFirestore, collection, query, where, orderBy, limit, onSnapshot } from 'firebase/firestore';
+import { app } from '../firebase';
+
+const categories = ['dance', 'academic'];
+
+export default function MentorPanel() {
+  const [tips, setTips] = useState({});
+
+  useEffect(() => {
+    const db = getFirestore(app);
+    const unsubs = categories.map(cat => {
+      const q = query(
+        collection(db, 'logs'),
+        where('agentName', '==', 'mentor-agent'),
+        where('inputSummary.focus', '==', cat),
+        orderBy('timestamp', 'desc'),
+        limit(1)
+      );
+      return onSnapshot(q, snap => {
+        let tip;
+        snap.forEach(doc => {
+          const data = doc.data();
+          tip = data.outputSummary?.tip || data.outputSummary || '';
+        });
+        setTips(prev => ({ ...prev, [cat]: tip }));
+      });
+    });
+    return () => unsubs.forEach(u => u());
+  }, []);
+
+  return (
+    <div className="bg-white/10 p-4 rounded shadow mb-4">
+      <h3 className="font-semibold mb-2">Latest Mentor Tips</h3>
+      <ul className="space-y-1 text-sm">
+        {categories.map(cat => (
+          <li key={cat} className="flex justify-between">
+            <span className="font-medium capitalize">{cat}:</span>
+            <span className="ml-2">{tips[cat] || 'No tip found.'}</span>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- fetch board, mentor and guardian logs from Firestore
- show panels for summaries, mentor tips, and compliance logs
- add collapsible Agent Guidance section in `App`

## Testing
- `npm test` *(fails: Cannot find module 'ajv')*

------
https://chatgpt.com/codex/tasks/task_e_68665f43bf0083239f4824d3a0b23ccb