### PR TITLE
Add agent output cards

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -12,6 +12,9 @@ import AnomalyPanel from "./components/AnomalyPanel";
 import TrendsPanel from "./components/TrendsPanel";
 import LifecycleTimeline from "./components/LifecycleTimeline";
 import InsightsChart from "./components/InsightsChart";
+import ResumeCard from "./components/ResumeCard";
+import RoadmapCard from "./components/RoadmapCard";
+import OpportunityCard from "./components/OpportunityCard";
 import { DashboardDataProvider } from "./context/DashboardDataContext";
 
 const sections = {
@@ -166,6 +169,13 @@ function App() {
               />
             );
           })}
+        </div>
+
+        <div className="mb-4">
+          <h2 className="font-semibold mb-2">Agent Outputs</h2>
+          <ResumeCard />
+          <RoadmapCard />
+          <OpportunityCard />
         </div>
 
         {showAnomaliesFor && (

--- a/frontend/src/components/OpportunityCard.jsx
+++ b/frontend/src/components/OpportunityCard.jsx
@@ -1,0 +1,46 @@
+import React, { useEffect, useState } from 'react';
+import { getFirestore, collection, query, limit, onSnapshot } from 'firebase/firestore';
+import { app, auth } from '../firebase';
+
+const OpportunityCard = () => {
+  const [items, setItems] = useState([]);
+
+  useEffect(() => {
+    const uid = auth.currentUser?.uid;
+    if (!uid) return;
+    const db = getFirestore(app);
+    const q = query(collection(db, 'users', uid, 'opportunities'), limit(1));
+    const unsub = onSnapshot(q, snap => {
+      let arr = [];
+      snap.forEach(doc => {
+        const data = doc.data();
+        if (Array.isArray(data.opportunities)) arr = data.opportunities;
+      });
+      setItems(arr);
+    });
+    return () => unsub();
+  }, []);
+
+  if (!items.length) return null;
+
+  return (
+    <div className="bg-white/10 backdrop-blur p-3 rounded shadow mb-4 max-h-40 overflow-y-auto">
+      <h4 className="font-semibold mb-2">Opportunities</h4>
+      <ul className="list-disc pl-4 text-sm space-y-1">
+        {items.map((item, idx) => (
+          <li key={idx}>
+            {item.link ? (
+              <a href={item.link} target="_blank" rel="noreferrer" className="underline">
+                {item.title}
+              </a>
+            ) : (
+              item.title
+            )}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+};
+
+export default OpportunityCard;

--- a/frontend/src/components/ResumeCard.jsx
+++ b/frontend/src/components/ResumeCard.jsx
@@ -1,0 +1,34 @@
+import React, { useEffect, useState } from 'react';
+import { getFirestore, collection, query, limit, onSnapshot } from 'firebase/firestore';
+import { app, auth } from '../firebase';
+
+const ResumeCard = () => {
+  const [summary, setSummary] = useState('');
+
+  useEffect(() => {
+    const uid = auth.currentUser?.uid;
+    if (!uid) return;
+    const db = getFirestore(app);
+    const q = query(collection(db, 'users', uid, 'resume'), limit(1));
+    const unsub = onSnapshot(q, snap => {
+      let text = '';
+      snap.forEach(doc => {
+        const data = doc.data();
+        if (data.summary) text = data.summary;
+      });
+      setSummary(text);
+    });
+    return () => unsub();
+  }, []);
+
+  if (!summary) return null;
+
+  return (
+    <div className="bg-white/10 backdrop-blur p-3 rounded shadow mb-4 max-h-40 overflow-y-auto">
+      <h4 className="font-semibold mb-2">Resume Summary</h4>
+      <p className="text-sm whitespace-pre-wrap">{summary}</p>
+    </div>
+  );
+};
+
+export default ResumeCard;

--- a/frontend/src/components/RoadmapCard.jsx
+++ b/frontend/src/components/RoadmapCard.jsx
@@ -1,0 +1,40 @@
+import React, { useEffect, useState } from 'react';
+import { getFirestore, collection, query, limit, onSnapshot } from 'firebase/firestore';
+import { app, auth } from '../firebase';
+
+const RoadmapCard = () => {
+  const [steps, setSteps] = useState([]);
+
+  useEffect(() => {
+    const uid = auth.currentUser?.uid;
+    if (!uid) return;
+    const db = getFirestore(app);
+    const q = query(collection(db, 'users', uid, 'roadmap'), limit(1));
+    const unsub = onSnapshot(q, snap => {
+      let arr = [];
+      snap.forEach(doc => {
+        const data = doc.data();
+        if (Array.isArray(data.roadmap)) arr = data.roadmap;
+      });
+      setSteps(arr);
+    });
+    return () => unsub();
+  }, []);
+
+  if (!steps.length) return null;
+
+  return (
+    <div className="bg-white/10 backdrop-blur p-3 rounded shadow mb-4 max-h-40 overflow-y-auto">
+      <h4 className="font-semibold mb-2">Roadmap</h4>
+      <ul className="list-disc pl-4 text-sm space-y-1">
+        {steps.map((step, idx) => (
+          <li key={idx}>
+            <span className="font-medium">{step.phase}:</span> {step.description}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+};
+
+export default RoadmapCard;


### PR DESCRIPTION
## Summary
- add `ResumeCard`, `RoadmapCard`, and `OpportunityCard` components
- display these new components in an "Agent Outputs" section of `App.jsx`
- fetch the latest Firestore output for each card

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68665f3f51508323a5278576ec30ca86