### PR TITLE
Add AgentSync streaming visuals

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -5,6 +5,8 @@ import { getFunctions, httpsCallable } from "firebase/functions";
 import { signInWithGoogle } from "./auth";
 import { app } from "./firebase";
 import CanvasNetwork from "./components/CanvasNetwork";
+import AgentSyncPanel from "./components/AgentSyncPanel";
+import useAgentSync from "./hooks/useAgentSync";
 import OnboardingOverlay from "./components/OnboardingOverlay";
 import SectionNav from "./components/SectionNav";
 import AgentCard from "./components/AgentCard";
@@ -50,6 +52,7 @@ function App() {
   const [registry, setRegistry] = useState([]);
   const [showAnomaliesFor, setShowAnomaliesFor] = useState(null);
   const [showLifecycleFor, setShowLifecycleFor] = useState(null);
+  const syncEvents = useAgentSync('demo-run');
 
   useEffect(() => {
     fetch('/config/agents.json')
@@ -198,7 +201,14 @@ function App() {
         <InsightsChart />
 
         <button onClick={() => triggerPulse("core")}>Trigger Core Pulse</button>
-        <CanvasNetwork ref={canvasRef} agents={agents} width={500} height={300} />
+        <CanvasNetwork
+          ref={canvasRef}
+          agents={agents}
+          width={500}
+          height={300}
+          events={syncEvents}
+        />
+        <AgentSyncPanel events={syncEvents} />
       </div>
     </DashboardDataProvider>
   );

--- a/frontend/src/components/AgentSyncPanel.jsx
+++ b/frontend/src/components/AgentSyncPanel.jsx
@@ -1,0 +1,18 @@
+import React from 'react';
+
+export default function AgentSyncPanel({ events = [] }) {
+  return (
+    <div className="bg-white/10 backdrop-blur p-3 rounded shadow mb-4">
+      <h4 className="font-semibold mb-2">Recent Agent Sync</h4>
+      <ul className="text-sm space-y-1">
+        {events.slice(0, 10).map((e, idx) => (
+          <li key={idx} className="flex justify-between">
+            <span>{e._agentId} - {e.stepType || e.type}</span>
+            <span className="text-xs text-gray-400">{e._timestamp}</span>
+          </li>
+        ))}
+        {events.length === 0 && <li>No sync events.</li>}
+      </ul>
+    </div>
+  );
+}

--- a/frontend/src/hooks/useAgentSync.js
+++ b/frontend/src/hooks/useAgentSync.js
@@ -1,0 +1,45 @@
+import { useEffect, useState } from 'react';
+import { auth, app } from '../firebase';
+
+export default function useAgentSync(runId) {
+  const [events, setEvents] = useState([]);
+
+  useEffect(() => {
+    if (!runId) return;
+    let source;
+    let isMounted = true;
+
+    const connect = async () => {
+      try {
+        const token = await auth.currentUser?.getIdToken();
+        const url = `https://us-central1-${app.options.projectId}.cloudfunctions.net/agentSyncSubscribe?runId=${runId}&token=${token}`;
+        source = new EventSource(url);
+        source.onmessage = evt => {
+          try {
+            const data = JSON.parse(evt.data);
+            if (isMounted) {
+              setEvents(prev => [data, ...prev].slice(0, 20));
+            }
+          } catch (err) {
+            console.error('Invalid AgentSync payload', err);
+          }
+        };
+        source.onerror = () => {
+          if (source) source.close();
+          setTimeout(connect, 1000);
+        };
+      } catch (err) {
+        console.error('AgentSync subscribe failed', err);
+      }
+    };
+
+    connect();
+
+    return () => {
+      isMounted = false;
+      if (source) source.close();
+    };
+  }, [runId]);
+
+  return events;
+}


### PR DESCRIPTION
## Summary
- stream agent sync data into the React app via a new hook
- visualize connections and pulses on CanvasNetwork when sync events arrive
- show recent sync events in an optional AgentSyncPanel

## Testing
- `npm test --silent` *(fails: Cannot find module 'ajv')*

------
https://chatgpt.com/codex/tasks/task_e_68665f36bb2c8323b7b278e7709a2911