### PR TITLE
Fix missing Ajv dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2618,6 +2618,8 @@
     },
     "node_modules/ajv": {
       "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
+      "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
## Summary
- install `ajv` so `npm test` runs without missing-module errors

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_686660e407708323868fd7814fc22d1b