### PR TITLE
Fix engine version and add robust install script

### DIFF
--- a/functions/package.json
+++ b/functions/package.json
@@ -2,7 +2,7 @@
   "name": "functions",
   "description": "Firebase Cloud Functions for Opportunity Engine",
   "engines": {
-    "node": "18"
+    "node": ">=18.0.0 <=20.x"
   },
   "dependencies": {
     "firebase-admin": "^11.0.0",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "deploy:preview:all": "npm run build && firebase hosting:channel:deploy preview"
   },
   "engines": {
-    "node": "18"
+    "node": ">=18.0.0 <=20.x"
   },
   "dependencies": {
     "eventsource": "^4.0.0",

--- a/scripts/robust-install.sh
+++ b/scripts/robust-install.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+# Installs npm dependencies with engine fallback and cleans proxy config
+set -e
+
+# Unset HTTP proxy environment variables to avoid npm warnings
+unset http_proxy HTTPS_PROXY HTTP_PROXY https_proxy npm_config_http_proxy npm_config_https_proxy
+
+run_npm_install() {
+  local dir="$1"
+  if [ -n "$dir" ]; then
+    (cd "$dir" && npm install)
+  else
+    npm install
+  fi
+}
+
+install_with_fallback() {
+  local dir="$1"
+  if run_npm_install "$dir"; then
+    return 0
+  else
+    echo "npm install failed, retrying with --engine-strict=false" >&2
+    if [ -n "$dir" ]; then
+      (cd "$dir" && npm install --engine-strict=false)
+    else
+      npm install --engine-strict=false
+    fi
+  fi
+}
+
+# install root dependencies
+if [ -f package.json ]; then
+  install_with_fallback
+fi
+
+# install functions dependencies if present
+if [ -f functions/package.json ]; then
+  install_with_fallback functions
+fi
+
+# install frontend dependencies if present
+if [ -f frontend/package.json ]; then
+  install_with_fallback frontend
+fi


### PR DESCRIPTION
## Summary
- relax Node.js version requirements for the app and functions
- provide a `robust-install.sh` script that unsets proxy variables and retries npm install without engine strictness

## Testing
- `npm test --silent`
- `./scripts/robust-install.sh` *(fails: ENETUNREACH on fetching firebase-functions)*

------
https://chatgpt.com/codex/tasks/task_e_68666b5c03548323a18d23745bf0c2e4