### PR TITLE
Add Cloud Run Dockerfile & workflow

### DIFF
--- a/.github/workflows/cloud-run-deploy.yml
+++ b/.github/workflows/cloud-run-deploy.yml
@@ -1,0 +1,25 @@
+name: Cloud Run Deploy
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    env:
+      PROJECT_ID: ${{ secrets.PROJECT_ID }}
+    steps:
+      - uses: actions/checkout@v3
+      - uses: google-github-actions/setup-gcloud@v1
+        with:
+          project_id: ${{ env.PROJECT_ID }}
+          service_account_key: ${{ secrets.GCP_SA_KEY }}
+      - name: Deploy to Cloud Run
+        run: |
+          gcloud run deploy node-backend \
+            --source ./functions \
+            --region us-central1 \
+            --platform managed \
+            --project $PROJECT_ID \
+            --allow-unauthenticated

--- a/functions/Dockerfile
+++ b/functions/Dockerfile
@@ -1,0 +1,5 @@
+FROM node:18-slim
+WORKDIR /app
+COPY . .
+RUN npm ci --omit=dev
+CMD ["npm", "start"]


### PR DESCRIPTION
## Summary
- add Dockerfile for Cloud Run deployment under `functions/`
- create GitHub Actions workflow to deploy Cloud Run service from `functions/`

## Testing
- `npm test --silent` *(fails: Cannot find module 'ajv')*
- `npm ci --silent` *(fails: no output due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68667890d29883239d1d88c34486176b