### PR TITLE
Use secret for dev deploy token

### DIFF
--- a/.github/workflows/firebase-dev-deploy.yml
+++ b/.github/workflows/firebase-dev-deploy.yml
@@ -26,4 +26,4 @@ jobs:
       - name: Install Firebase CLI
         run: npm install -g firebase-tools
       - name: Deploy to Firebase
-        run: firebase deploy --token "1//06uL_yps5dZtUCgYIARAAGAYSNwF-L9lrsP-qG2V_vuSr3Wpb5F71R1di2mrLg33nnEDaUEWbb5NAxjqYKurCaapuJxK2YDMbI"
+        run: firebase deploy --token "${{ secrets.FIREBASE_TOKEN }}"

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ On CI, auth is handled via `FIREBASE_TOKEN`.
 ### CI Deploys
 
 1. Generate a token locally using `firebase login:ci`.
-2. Store it as `FIREBASE_TOKEN` in GitHub Actions secrets or as
+2. Store it as `FIREBASE_TOKEN` in your repository's GitHub Actions secrets (Settings > Secrets and variables > Actions). Alternatively, you can store it as
    `firebase-ci-token` in Cloud Build's Secret Manager.
 3. The CI workflow injects this token so `firebase deploy` runs without
    interactive login. If the token expires, re-run the command above.

--- a/docs/ci-workflows.md
+++ b/docs/ci-workflows.md
@@ -15,7 +15,7 @@ Each workflow automates part of the deploy or validation process.
 5. Deploy to a preview Hosting channel with `firebase hosting:channel:deploy preview`.
 
 **Environment Variables**
-- `FIREBASE_TOKEN` &mdash; Firebase deploy token from secrets.
+- `FIREBASE_TOKEN` &mdash; Firebase deploy token from secrets. Add this secret under **Settings > Secrets and variables > Actions** in your GitHub repository.
 - `NODE_VERSION` &mdash; set to `18.x`.
 
 ## Firebase CI/CD (`firebase.yml`)

--- a/public/README.md
+++ b/public/README.md
@@ -113,7 +113,7 @@ On CI, auth is handled via `FIREBASE_TOKEN`.
 ### CI Deploys
 
 1. Generate a token locally using `firebase login:ci`.
-2. Store it as `FIREBASE_TOKEN` in GitHub Actions secrets or as
+2. Store it as `FIREBASE_TOKEN` in your repository's GitHub Actions secrets (Settings > Secrets and variables > Actions). Alternatively, you can store it as
    `firebase-ci-token` in Cloud Build's Secret Manager.
 3. The CI workflow injects this token so `firebase deploy` runs without
    interactive login. If the token expires, re-run the command above.


### PR DESCRIPTION
## Summary
- fetch Firebase token from `${{ secrets.FIREBASE_TOKEN }}` in dev deploy workflow
- document saving this secret in GitHub settings

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68667b00373c83239c0b3a76dfd5178e