### PR TITLE
Configure npm registry for Cloud Run deploy

### DIFF
--- a/.github/workflows/cloud-run-deploy.yml
+++ b/.github/workflows/cloud-run-deploy.yml
@@ -11,6 +11,13 @@ jobs:
       PROJECT_ID: ${{ secrets.PROJECT_ID }}
     steps:
       - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
+      - name: Configure npm registry
+        run: echo "registry=https://registry.npmjs.org/" > ~/.npmrc
+      - name: Install dependencies
+        run: npm ci --omit=dev --prefix functions
       - uses: google-github-actions/setup-gcloud@v1
         with:
           project_id: ${{ env.PROJECT_ID }}


### PR DESCRIPTION
## Summary
- ensure npm registry is explicitly set in cloud-run deploy workflow
- install functions dependencies before deployment

## Testing
- `npm install`
- `npm install --prefix functions`
- `npm test --silent`
- `npm --prefix functions test --silent`


------
https://chatgpt.com/codex/tasks/task_e_68667aff8d9c8323963b2921f8e6b4cd