### PR TITLE
Fix Cloud Run npm registry config

### DIFF
--- a/.github/workflows/cloud-run-deploy.yml
+++ b/.github/workflows/cloud-run-deploy.yml
@@ -15,9 +15,11 @@ jobs:
         with:
           node-version: 18
       - name: Configure npm registry
-        run: echo "registry=https://registry.npmjs.org/" > ~/.npmrc
+        working-directory: functions
+        run: echo "registry=https://registry.npmjs.org/" > .npmrc
       - name: Install dependencies
-        run: npm ci --omit=dev --prefix functions
+        working-directory: functions
+        run: npm ci --omit=dev
       - uses: google-github-actions/setup-gcloud@v1
         with:
           project_id: ${{ env.PROJECT_ID }}


### PR DESCRIPTION
## Summary
- ensure the Cloud Run deploy workflow sets up `.npmrc` in the `functions` directory

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68667cbf64508323b7e83fa0f2278a42