### PR TITLE
Fix npm proxy warnings

### DIFF
--- a/.github/workflows/cloud-run-deploy.yml
+++ b/.github/workflows/cloud-run-deploy.yml
@@ -17,6 +17,10 @@ jobs:
       - name: Configure npm registry
         working-directory: functions
         run: echo "registry=https://registry.npmjs.org/" > .npmrc
+      - name: Clean up obsolete npm proxy config
+        run: |
+          npm config delete http-proxy
+          npm config delete https-proxy
       - name: Install dependencies
         working-directory: functions
         run: npm ci --omit=dev


### PR DESCRIPTION
## Summary
- clean up obsolete npm proxy config before installing dependencies in Cloud Run deployment workflow

## Testing
- `npm ci --silent`
- `npm --prefix functions ci --silent`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6866819c4c8883238d9c94822bbcaca0