### PR TITLE
Fix Cloud Run buildpack context

### DIFF
--- a/.github/workflows/cloud-run-deploy.yml
+++ b/.github/workflows/cloud-run-deploy.yml
@@ -11,6 +11,9 @@ jobs:
       PROJECT_ID: ${{ secrets.PROJECT_ID }}
     steps:
       - uses: actions/checkout@v3
+      - name: Verify functions package.json
+        run: |
+          test -f functions/package.json || { echo "\u274c Missing package.json"; exit 1; }
       - uses: actions/setup-node@v3
         with:
           node-version: 18
@@ -37,10 +40,11 @@ jobs:
           project_id: ${{ env.PROJECT_ID }}
           service_account_key: ${{ secrets.GCP_SA_KEY }}
       - name: Deploy to Cloud Run
+        working-directory: functions
         run: |
           # Using --source with Buildpacks avoids Google_ENTRYPOINT issues
           gcloud run deploy node-backend \
-            --source ./functions \
+            --source . \
             --region us-central1 \
             --platform managed \
             --project $PROJECT_ID \


### PR DESCRIPTION
## Summary
- verify functions/package.json exists before deploying
- run Cloud Run deployment inside the functions folder so Buildpacks detect package.json

## Testing
- `npm --prefix functions install`
- `npm --prefix functions run build` *(fails: Missing script)*
- `timeout 3 npm --prefix functions start` *(fails: Cannot find module 'firebase-admin')*

------
https://chatgpt.com/codex/tasks/task_e_686687e9b22083239317d45d5f387fe6