### PR TITLE
docs: troubleshooting for firebase-admin

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,27 @@ curl -X POST https://<REGION>-<PROJECT>.cloudfunctions.net/runWebsiteAnalysis \
 
 The response contains the captured flow state and outputs for each step.
 
+### Troubleshooting
+
+If Cloud Functions report `Error: Cannot find module 'firebase-admin'`, install
+dependencies explicitly:
+
+```bash
+cd functions
+npm install firebase-admin
+npm --prefix functions install
+```
+
+Ensure `firebase-admin` appears in `functions/package.json` under
+`dependencies`. Validate the installation with:
+
+```bash
+npm --prefix functions run build
+timeout 3 npm --prefix functions start
+```
+
+Both commands should exit without errors.
+
 ## Firebase Project Info
 
 - **Project Name:** Super Intelligence  

--- a/functions/package.json
+++ b/functions/package.json
@@ -13,6 +13,7 @@
   },
   "scripts": {
     "start": "node index.js",
+    "build": "echo 'no build step'",
     "test": "node testRoadmapAgent.js && node testResumeAgent.js && node testOpportunityAgent.js && node testOnboardingFlow.js && node testInsightsAgent.js && node testAnomalyAgent.js && node testTrendsAgent.js && node testSummarizeReplayLogs.js && node testLifecycleFlow.js && node testFeedbackAction.js"
   }
 }


### PR DESCRIPTION
## Summary
- add troubleshooting section to README for missing `firebase-admin` error
- provide a dummy `build` script for Cloud Functions

## Testing
- `npm --prefix functions run build`
- `timeout 3 npm --prefix functions start`


------
https://chatgpt.com/codex/tasks/task_e_686689053aac83239bff67cfecb70b7e