### PR TITLE
Fix Cloud Run build context

### DIFF
--- a/.github/workflows/cloud-run-deploy.yml
+++ b/.github/workflows/cloud-run-deploy.yml
@@ -10,6 +10,7 @@ jobs:
     env:
       PROJECT_ID: ${{ secrets.PROJECT_ID }}
       SERVICE_NAME: node-backend
+      GOOGLE_ENTRYPOINT: "npm --prefix functions start"
     steps:
       - uses: actions/checkout@v3
       - name: Verify functions package.json
@@ -17,7 +18,7 @@ jobs:
           test -f functions/package.json || { echo "\u274c Missing package.json"; exit 1; }
       - uses: actions/setup-node@v3
         with:
-          node-version: 18
+          node-version: 20
       - name: Configure npm registry
         working-directory: functions
         run: echo "registry=https://registry.npmjs.org/" > .npmrc
@@ -40,13 +41,10 @@ jobs:
         with:
           project_id: ${{ env.PROJECT_ID }}
           service_account_key: ${{ secrets.GCP_SA_KEY }}
-      - name: Build container image
-        run: gcloud builds submit functions --tag gcr.io/$PROJECT_ID/$SERVICE_NAME --project $PROJECT_ID
       - name: Deploy to Cloud Run
         run: |
           gcloud run deploy $SERVICE_NAME \
-            --image gcr.io/$PROJECT_ID/$SERVICE_NAME \
+            --source functions \
             --region us-central1 \
-            --platform managed \
             --project $PROJECT_ID \
             --allow-unauthenticated

--- a/functions/Procfile
+++ b/functions/Procfile
@@ -1,0 +1,1 @@
+web: npm --prefix functions start


### PR DESCRIPTION
## Summary
- ensure Cloud Run build uses Node.js 20
- set `GOOGLE_ENTRYPOINT` so buildpacks detect the start command
- deploy from `functions/` using buildpacks
- add Procfile with start command for buildpack fallback

## Testing
- `npm install --silent`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6866920a4bf4832388d304a0ed5ab066