### PR TITLE
Fix Cloud Build vite dependency

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -47,7 +47,7 @@
         "js-yaml": "^4.1.0"
       },
       "engines": {
-        "node": "18"
+        "node": ">=18.0.0 <=20.x"
       }
     },
     "node_modules/@adobe/css-tools": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -8,16 +8,17 @@
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.3.0",
     "@testing-library/user-event": "^13.5.0",
+    "chart.js": "^4.4.1",
     "firebase": "^11.10.0",
     "framer-motion": "^12.23.0",
     "lucide-react": "^0.321.0",
-    "chart.js": "^4.4.1",
     "react": "^19.1.0",
     "react-chartjs-2": "^5.2.0",
     "react-dom": "^19.1.0",
     "react-scripts": "5.0.1",
     "super-intelligence-app": "file:..",
-    "web-vitals": "^2.1.4"
+    "web-vitals": "^2.1.4",
+    "vite": "^6.3.5"
   },
   "scripts": {
     "start": "react-scripts start",
@@ -46,7 +47,6 @@
     ]
   },
   "devDependencies": {
-    "@vitejs/plugin-react": "^4.6.0",
-    "vite": "^6.3.5"
+    "@vitejs/plugin-react": "^4.6.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "sync-agents": "node scripts/syncAgentsConfig.js",
     "test": "npm run sync-agents && node scripts/validateAgentMetadata.js && npm --prefix functions test --silent",
     "dev": "npm --prefix frontend run dev",
-    "build": "npm --prefix frontend run build",
+    "build": "npm --prefix frontend install && npm --prefix frontend run build",
     "preview": "npm --prefix frontend run preview",
     "deploy": "firebase deploy --only hosting",
     "deploy:preview": "firebase hosting:channel:deploy preview",


### PR DESCRIPTION
## Summary
- run `npm --prefix frontend install` before building to ensure Cloud Build picks up vite
- move `vite` from devDependencies to dependencies

## Testing
- `npm install`
- `npm --prefix functions install`
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_6866de677e5c83238028ef78e475db42