### PR TITLE
Fix missing ajv dependency

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -12,7 +12,6 @@
         "@testing-library/jest-dom": "^6.6.3",
         "@testing-library/react": "^16.3.0",
         "@testing-library/user-event": "^13.5.0",
-        "ajv": "^8.12.0",
         "chart.js": "^4.4.1",
         "firebase": "^11.10.0",
         "framer-motion": "^12.23.0",
@@ -25,7 +24,8 @@
         "web-vitals": "^2.1.4"
       },
       "devDependencies": {
-        "@vitejs/plugin-react": "^4.6.0"
+        "@vitejs/plugin-react": "^4.6.0",
+        "ajv": "^8.17.1"
       }
     },
     "..": {
@@ -1998,6 +1998,7 @@
       "version": "8.17.1",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
@@ -2271,12 +2272,14 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-uri": {
       "version": "3.0.6",
       "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.0.6.tgz",
       "integrity": "sha512-Atfo14OibSv5wAp4VWNsFYE1AchQRTv9cBGWET4pZWHzYshFSS9NQI6I57rdKn9croWVMbYFbLhJ+yJvmZIIHw==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -2470,6 +2473,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/json5": {
@@ -2744,6 +2748,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
       "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -16,9 +16,8 @@
     "react-chartjs-2": "^5.2.0",
     "react-dom": "^19.1.0",
     "super-intelligence-app": "file:..",
-    "web-vitals": "^2.1.4",
     "vite": "^6.3.5",
-    "ajv": "^8.12.0"
+    "web-vitals": "^2.1.4"
   },
   "scripts": {
     "start": "vite",
@@ -46,6 +45,7 @@
     ]
   },
   "devDependencies": {
-    "@vitejs/plugin-react": "^4.6.0"
+    "@vitejs/plugin-react": "^4.6.0",
+    "ajv": "^8.17.1"
   }
 }


### PR DESCRIPTION
## Summary
- move `ajv` from dependencies to devDependencies
- update lockfile

## Testing
- `npm --prefix frontend test`

------
https://chatgpt.com/codex/tasks/task_e_6866ee76987883239b13ade8042eb948