### PR TITLE
Fix Cloud Run port binding

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: npm run preview
+web: npm run preview -- --port $PORT --host 0.0.0.0


### PR DESCRIPTION
## Summary
- bind Vite preview server to Cloud Run's `$PORT` on `0.0.0.0`

## Testing
- `npm install`
- `npm --prefix functions install`
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_6866f17324688323ba810e136b6429ad