### PR TITLE
Fix Vite preview port for Cloud Run

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: npm run preview -- --port $PORT --host 0.0.0.0
+web: npm --prefix frontend run preview

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -24,7 +24,7 @@
     "build": "vite build",
     "test": "echo 'No tests defined'",
     "dev": "vite",
-    "preview": "vite preview"
+    "preview": "vite preview --host 0.0.0.0 --port $PORT"
   },
   "eslintConfig": {
     "extends": [


### PR DESCRIPTION
## Summary
- bind Vite preview to `0.0.0.0` and Cloud Run `$PORT`
- simplify `Procfile` to run frontend preview script

## Testing
- `npm test --silent` *(fails: Cannot find module 'ajv')*

------
https://chatgpt.com/codex/tasks/task_e_6866f5887ccc8323a717353fd421f682