### PR TITLE
Extend Cloud Run timeout

### DIFF
--- a/.github/workflows/cloud-run-deploy.yml
+++ b/.github/workflows/cloud-run-deploy.yml
@@ -51,5 +51,6 @@ jobs:
             --source . \
             --region us-central1 \
             --project $PROJECT_ID \
+            --timeout=300s \
             --allow-unauthenticated \
             --build-env-vars "GOOGLE_ENTRYPOINT=${{ env.GOOGLE_ENTRYPOINT }}"


### PR DESCRIPTION
## Summary
- allow extra time for Cloud Run to boot before declaring failure

## Testing
- `npm install`
- `npm --prefix functions install`
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_6866f81781c88323bc87ce8231223293