### PR TITLE
Add startup logs and healthcheck for Cloud Run

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: npm --prefix frontend run preview
+web: node scripts/startPreview.js

--- a/frontend/public/healthcheck.html
+++ b/frontend/public/healthcheck.html
@@ -1,0 +1,7 @@
+<!DOCTYPE html>
+<html lang="en">
+<head><meta charset="UTF-8"><title>Health Check</title></head>
+<body>
+  <p>OK</p>
+</body>
+</html>

--- a/scripts/startPreview.js
+++ b/scripts/startPreview.js
@@ -1,0 +1,15 @@
+const { spawn } = require('child_process');
+
+console.log('[startup] Launching Vite preview...');
+console.log(`[startup] process.env.PORT = ${process.env.PORT}`);
+console.log('[startup] Executing: npm --prefix frontend run preview');
+
+const child = spawn('npm', ['--prefix', 'frontend', 'run', 'preview'], {
+  stdio: 'inherit',
+  env: process.env,
+});
+
+child.on('close', (code) => {
+  console.log(`[startup] Vite preview exited with code ${code}`);
+  process.exit(code);
+});


### PR DESCRIPTION
## Summary
- log port binding in new `startPreview` script and run Vite preview via Procfile
- expose `/healthcheck.html` for simple Cloud Run health checks

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6866fb9d8ee48323a04d8ca4dde63348