### PR TITLE
Bind Vite preview to Cloud Run port

### DIFF
--- a/scripts/startPreview.js
+++ b/scripts/startPreview.js
@@ -2,12 +2,16 @@ const { spawn } = require('child_process');
 
 console.log('[startup] Launching Vite preview...');
 console.log(`[startup] process.env.PORT = ${process.env.PORT}`);
-console.log('[startup] Executing: npm --prefix frontend run preview');
 
-const child = spawn('npm', ['--prefix', 'frontend', 'run', 'preview'], {
+const port = process.env.PORT || 8080;
+console.log(`[startup] Executing: npm --prefix frontend exec vite preview --host 0.0.0.0 --port ${port}`);
+
+const child = spawn('npm', ['--prefix', 'frontend', 'exec', 'vite', 'preview', '--', '--host', '0.0.0.0', '--port', port], {
   stdio: 'inherit',
   env: process.env,
 });
+
+console.log(`[startup] Listening on PORT ${port} ...`);
 
 child.on('close', (code) => {
   console.log(`[startup] Vite preview exited with code ${code}`);


### PR DESCRIPTION
## Summary
- ensure Vite preview binds to `process.env.PORT`
- log the port number after spawning Vite

## Testing
- `PORT=8080 node scripts/startPreview.js`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6867026fb5108323b0b478301d294a82