### PR TITLE
Fix Vite port binding

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,6 @@
     "test": "if [ \"$TEST\" = \"false\" ]; then echo 'Skipping tests'; else npm run sync-agents && node scripts/validateAgentMetadata.js && npm --prefix functions test --silent; fi",
     "dev": "npm --prefix frontend run dev",
     "build": "npm --prefix frontend install && npm --prefix frontend run build",
-    "preview": "npm --prefix frontend run preview",
     "deploy": "firebase deploy --only hosting",
     "deploy:preview": "firebase hosting:channel:deploy preview",
     "deploy:all": "npm run build && firebase deploy",

--- a/scripts/startPreview.js
+++ b/scripts/startPreview.js
@@ -1,12 +1,14 @@
 const { spawn } = require('child_process');
+const path = require('path');
 
 console.log('[startup] Launching Vite preview...');
 console.log(`[startup] process.env.PORT = ${process.env.PORT}`);
 
 const port = process.env.PORT || 8080;
-console.log(`[startup] Executing: npm --prefix frontend exec vite preview --host 0.0.0.0 --port ${port}`);
+console.log(`[startup] Executing: vite preview --host 0.0.0.0 --port ${port}`);
 
-const child = spawn('npm', ['--prefix', 'frontend', 'exec', 'vite', 'preview', '--', '--host', '0.0.0.0', '--port', port], {
+const child = spawn('npx', ['vite', 'preview', '--host', '0.0.0.0', '--port', port], {
+  cwd: path.join(__dirname, '..', 'frontend'),
   stdio: 'inherit',
   env: process.env,
 });


### PR DESCRIPTION
## Summary
- remove unused preview npm script
- start Vite preview directly with explicit host/port

## Testing
- `npm test --silent`
- `PORT=8080 node scripts/startPreview.js`

------
https://chatgpt.com/codex/tasks/task_e_686706f758f88323b81c2c4843d8ead6