### PR TITLE
Allow Cloud Run hostname for Vite preview

### DIFF
--- a/frontend/vite.config.mjs
+++ b/frontend/vite.config.mjs
@@ -11,6 +11,9 @@ export default defineConfig(({ mode }) => {
     esbuild: {
       loader: 'jsx',
       include: /src\/.*\.[jt]sx?$/
+    },
+    preview: {
+      allowedHosts: ['super-intelligence-170923536461.europe-west1.run.app']
     }
   }
 })


### PR DESCRIPTION
## Summary
- enable Cloud Run hostname in `frontend/vite.config.mjs`

## Testing
- `npm run build`
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_68670cd8c6808323a152451307e0cca6