### PR TITLE
Fix Cloud Run build to serve React app

### DIFF
--- a/.github/workflows/cloud-run-deploy.yml
+++ b/.github/workflows/cloud-run-deploy.yml
@@ -11,42 +11,29 @@ jobs:
       PROJECT_ID: ${{ secrets.PROJECT_ID }}
       SERVICE_NAME: node-backend
       GOOGLE_REGION: us-central1
-      GOOGLE_ENTRYPOINT: "npm --prefix functions start"
+      GOOGLE_ENTRYPOINT: "node index.js"
     steps:
       - uses: actions/checkout@v3
-      - name: Verify functions package.json
-        run: |
-          test -f functions/package.json || { echo "\u274c Missing package.json"; exit 1; }
       - uses: actions/setup-node@v3
         with:
           node-version: 20
       - name: Configure npm registry
-        working-directory: functions
         run: echo "registry=https://registry.npmjs.org/" > .npmrc
-      - name: Clear deprecated npm proxy config
-        working-directory: functions
-        run: |
-          npm config delete http-proxy || true
-          npm config delete https-proxy || true
-          sed -i '/http-proxy/d;/https-proxy/d' .npmrc || true
       - name: Install dependencies
-        working-directory: functions
-        run: npm install
-      - name: Build functions
-        working-directory: functions
+        run: |
+          npm install
+          npm install --prefix frontend
+      - name: Build frontend
         run: npm run build
       - name: Run tests
-        working-directory: functions
         run: npm test
       - name: Verify start script
-        working-directory: functions
-        run: timeout 3 npm start || true
+        run: timeout 3 node index.js || true
       - uses: google-github-actions/setup-gcloud@v1
         with:
           project_id: ${{ env.PROJECT_ID }}
           service_account_key: ${{ secrets.GCP_SA_KEY }}
       - name: Deploy to Cloud Run
-        working-directory: functions
         run: |
           gcloud run deploy $SERVICE_NAME \
             --source . \

--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 const admin = require('firebase-admin');
 const express = require('express');
 const http = require('http');
+const path = require('path');
 const { initAgentSyncWs } = require('./functions/utils/agent-sync-ws');
 
 if (!process.env.GOOGLE_CLOUD_PROJECT && !process.env.FIREBASE_PROJECT_ID) {
@@ -30,6 +31,11 @@ console.log(`Firebase initialized for project ${projectId}`);
 const app = express();
 const server = http.createServer(app);
 initAgentSyncWs(server);
+
+app.use(express.static(path.join(__dirname, 'frontend', 'dist')));
+app.get('*', (req, res) => {
+  res.sendFile(path.join(__dirname, 'frontend', 'dist', 'index.html'));
+});
 
 const port = process.env.PORT || 3000;
 server.listen(port, () => {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "sync-agents": "node scripts/syncAgentsConfig.js",
     "test": "if [ \"$TEST\" = \"false\" ]; then echo 'Skipping tests'; else npm run sync-agents && node scripts/validateAgentMetadata.js && npm --prefix functions test --silent; fi",
     "dev": "npm --prefix frontend run dev",
-    "build": "npm --prefix frontend install && npm --prefix frontend run build",
+    "build": "npm --prefix frontend run build",
     "deploy": "firebase deploy --only hosting",
     "deploy:preview": "firebase hosting:channel:deploy preview",
     "deploy:all": "npm run build && firebase deploy",


### PR DESCRIPTION
## Summary
- update root build script
- serve `frontend/dist` with Express
- configure Cloud Run workflow to build and deploy from root

## Testing
- `npm install`
- `npm install --prefix frontend`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_686710452e68832396e6ffe88c5e6a4a