### PR TITLE
Fix Cloud Run build by running Vite

### DIFF
--- a/.github/workflows/cloud-run-deploy.yml
+++ b/.github/workflows/cloud-run-deploy.yml
@@ -12,6 +12,7 @@ jobs:
       SERVICE_NAME: node-backend
       GOOGLE_REGION: us-central1
       GOOGLE_ENTRYPOINT: "node index.js"
+      GOOGLE_NODE_RUN_SCRIPTS: build
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
@@ -41,7 +42,7 @@ jobs:
             --project $PROJECT_ID \
             --timeout=300s \
             --allow-unauthenticated \
-            --build-env-vars "GOOGLE_ENTRYPOINT=${{ env.GOOGLE_ENTRYPOINT }}"
+            --build-env-vars "GOOGLE_ENTRYPOINT=${{ env.GOOGLE_ENTRYPOINT }},GOOGLE_NODE_RUN_SCRIPTS=${{ env.GOOGLE_NODE_RUN_SCRIPTS }}"
       - name: Verify Cloud Run healthcheck
         run: |
           status=$(curl -s -o /dev/null -w "%{http_code}" https://${{ env.SERVICE_NAME }}-${{ env.GOOGLE_REGION }}.a.run.app/healthcheck.html)


### PR DESCRIPTION
## Summary
- run the `build` script during Cloud Run deploy so buildpacks install production deps

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68671bfd447083238aeb4a8c9394a8a8