### PR TITLE
Serve Vite build in Node server

### DIFF
--- a/index.js
+++ b/index.js
@@ -32,9 +32,11 @@ const app = express();
 const server = http.createServer(app);
 initAgentSyncWs(server);
 
-app.use(express.static(path.join(__dirname, 'frontend', 'dist')));
+const distPath = path.join(__dirname, 'frontend', 'dist');
+app.use(express.static(distPath));
+// Fallback to index.html so client-side routing works
 app.get('*', (req, res) => {
-  res.sendFile(path.join(__dirname, 'frontend', 'dist', 'index.html'));
+  res.sendFile(path.join(distPath, 'index.html'));
 });
 
 const port = process.env.PORT || 3000;


### PR DESCRIPTION
## Summary
- expose `distPath` in `index.js`
- serve `frontend/dist` with SPA fallback

## Testing
- `npm test --silent`
- `npm run build`
- `node index.js` and `curl http://localhost:3000/`


------
https://chatgpt.com/codex/tasks/task_e_6867238f6f7c8323b68fa6277a24f89b