### PR TITLE
Reduce frontend install memory

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,3 @@
 production=false
+progress=false
+audit=false

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,0 +1,11 @@
+steps:
+  - name: 'gcr.io/cloud-builders/npm'
+    args: ['ci']
+    id: Install backend
+    timeout: 600s
+
+  - name: 'gcr.io/cloud-builders/npm'
+    args: ['--prefix', 'frontend', 'install', '--omit=dev']
+    id: Install frontend
+    timeout: 600s
+    env: ['NODE_ENV=production']

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "test": "if [ \"$TEST\" = \"false\" ]; then echo 'Skipping tests'; else npm run sync-agents && node scripts/validateAgentMetadata.js && npm --prefix functions test --silent; fi",
     "dev": "npm --prefix frontend run dev",
     "build": "npm --prefix frontend run build",
-    "postinstall": "npm --prefix frontend install",
+    "postinstall": "npm --prefix frontend install --omit=dev",
     "deploy": "firebase deploy --only hosting",
     "deploy:preview": "firebase hosting:channel:deploy preview",
     "deploy:all": "npm run build && firebase deploy",


### PR DESCRIPTION
## Summary
- avoid dev dependency install in `postinstall`
- disable npm progress and audit for faster build
- add a simple `cloudbuild.yaml` with separate backend/frontend install steps

## Testing
- `npm test --silent` *(fails: Cannot find module 'ajv')*

------
https://chatgpt.com/codex/tasks/task_e_68673295baf08323a66e6961b7df8f92