### PR TITLE
Update ci-workflows docs for ajv

### DIFF
--- a/docs/ci-workflows.md
+++ b/docs/ci-workflows.md
@@ -10,7 +10,7 @@ Each workflow automates part of the deploy or validation process.
 **Steps**
 1. Checkout the repository and set up Node `18`.
 2. Install root and frontend dependencies.
-3. Install Ajv and the Firebase CLI.
+3. Install the Firebase CLI. The `ajv` package is now a regular dependency so it's installed during `npm install`.
 4. Run tests and build the project.
 5. Deploy to a preview Hosting channel with `firebase hosting:channel:deploy preview`.
 


### PR DESCRIPTION
## Summary
- document that `ajv` installs with the normal `npm install`
- remove outdated mention of manually installing Ajv

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6867381e073c83238b188d80973f947a