### PR TITLE
Fix Cloud Build OOM by removing frontend install from postinstall

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,3 +1,2 @@
-production=false
 progress=false
 audit=false

--- a/README.md
+++ b/README.md
@@ -86,13 +86,12 @@ Inspired by principles from:
    ```bash
    npm install --prefix functions
    ```
-3. Install frontend dependencies (this also runs automatically after the root
-   install):
+3. Install frontend dependencies:
    ```bash
    npm install --prefix frontend
    ```
-   This runs automatically after the root `npm install` via the
-   `postinstall` script in `package.json`.
+   Run this separately after the root install, since the `postinstall`
+   hook no longer installs the frontend for Cloud Build memory savings.
 4. Create environment files in `frontend/` using the provided example:
    ```bash
    cp frontend/.env.example frontend/.env

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -5,10 +5,10 @@ steps:
     timeout: 600s
 
   - name: 'gcr.io/cloud-builders/npm'
-    args: ['--prefix', 'frontend', 'install', '--omit=dev']
+    args: ['install', '--omit=dev']
+    dir: 'frontend'
     id: Install frontend
     timeout: 600s
-    env: ['NODE_ENV=production']
 
   - name: 'gcr.io/cloud-builders/npm'
     args: ['install']

--- a/package.json
+++ b/package.json
@@ -9,7 +9,6 @@
     "test": "if [ \"$TEST\" = \"false\" ]; then echo 'Skipping tests'; else npm run sync-agents && node scripts/validateAgentMetadata.js && npm --prefix functions test --silent; fi",
     "dev": "npm --prefix frontend run dev",
     "build": "npm --prefix frontend run build",
-    "postinstall": "npm --prefix frontend install --omit=dev",
     "deploy": "firebase deploy --only hosting",
     "deploy:preview": "firebase hosting:channel:deploy preview",
     "deploy:all": "npm run build && firebase deploy",


### PR DESCRIPTION
## Summary
- strip frontend install step from root `postinstall`
- keep only progress and audit settings in `.npmrc`
- install frontend separately in `cloudbuild.yaml`
- update README instructions

## Testing
- `npm test --silent` *(fails: Cannot find module 'ajv')*

------
https://chatgpt.com/codex/tasks/task_e_68673d0d6a5c832384c0bcc16061cdd0