### PR TITLE
Fix Cloud Build build/install pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,8 +90,8 @@ Inspired by principles from:
    ```bash
    npm install --prefix frontend
    ```
-   Run this separately after the root install, since the `postinstall`
-   hook no longer installs the frontend for Cloud Build memory savings.
+   Run this separately after the root install. The Cloud Build pipeline
+   also performs `npm install` so the Vite production build works.
 4. Create environment files in `frontend/` using the provided example:
    ```bash
    cp frontend/.env.example frontend/.env
@@ -123,10 +123,11 @@ On CI, auth is handled via `FIREBASE_TOKEN`.
 ### CI Deploys
 
 1. Generate a token locally using `firebase login:ci`.
-2. Store it as `FIREBASE_TOKEN` in your repository's GitHub Actions secrets (Settings > Secrets and variables > Actions). Alternatively, you can store it as
-   `firebase-ci-token` in Cloud Build's Secret Manager.
-3. The CI workflow injects this token so `firebase deploy` runs without
-   interactive login. If the token expires, re-run the command above.
+2. Store it as `firebase-ci-token` in Cloud Build's Secret Manager.
+3. Pushes to `main` trigger Cloud Build, which installs all dependencies,
+   runs tests, builds the frontend with Vite, deploys Firebase functions using
+   the secret token and finally updates the Cloud Run service with
+   `gcloud run deploy`.
 
 ### Build Frontend for Hosting
 
@@ -139,8 +140,8 @@ npm run build
 
 The command outputs static files in `frontend/build/`. Copy them to the repository's
 `public/` directory or set `hosting.public` in `firebase.json` to `frontend/build` so
-Firebase Hosting serves the build directory. Ensure these files are available before
-running:
+Firebase Hosting serves the build directory. Cloud Build runs `npm --prefix frontend run build`
+automatically during CI, but you can run it manually before:
 
 ```bash
 firebase deploy

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -5,7 +5,13 @@ steps:
     timeout: 600s
 
   - name: 'gcr.io/cloud-builders/npm'
-    args: ['install', '--omit=dev']
+    args: ['install']
+    dir: 'functions'
+    id: Install functions
+    timeout: 600s
+
+  - name: 'gcr.io/cloud-builders/npm'
+    args: ['install']
     dir: 'frontend'
     id: Install frontend
     timeout: 600s
@@ -13,7 +19,6 @@ steps:
   - name: 'gcr.io/cloud-builders/npm'
     args: ['install']
     id: Install test deps
-    dir: '.'
     timeout: 300s
 
   - name: 'gcr.io/cloud-builders/npm'
@@ -22,17 +27,25 @@ steps:
     timeout: 600s
 
   - name: 'gcr.io/cloud-builders/npm'
-    args: ['install']
-    dir: 'frontend'
-    id: Install frontend build deps
-    timeout: 600s
-
-  - name: 'gcr.io/cloud-builders/npm'
-    args: ['run', 'build']
-    dir: 'frontend'
+    args: ['--prefix', 'frontend', 'run', 'build']
     id: Build frontend
     timeout: 600s
 
+  - name: 'gcr.io/cloud-builders/npm'
+    entrypoint: bash
+    args:
+      - -c
+      - |
+          npm install -g firebase-tools
+          firebase deploy --only functions --token "$FIREBASE_TOKEN" --project "$PROJECT_ID"
+    id: Deploy functions
+    timeout: 1200s
+
   - name: 'gcr.io/cloud-builders/gcloud'
     args: ['run', 'deploy', 'super-intelligence', '--source=.', '--region=europe-west1']
-    id: Deploy
+    id: Deploy service
+
+availableSecrets:
+  secretManager:
+    - versionName: projects/$PROJECT_ID/secrets/firebase-ci-token/versions/latest
+      env: FIREBASE_TOKEN

--- a/docs/ci-workflows.md
+++ b/docs/ci-workflows.md
@@ -63,4 +63,4 @@ The repository does not currently include separate `deploy-prod.yml` or `test-ag
 
 ## Cloud Build (`cloudbuild.yaml`)
 
-Google Cloud Build uses the `cloudbuild.yaml` file located at the repo root to deploy the application. The pipeline installs only production dependencies at first with `npm install --omit=dev` to reduce memory usage, then runs a full `npm install` before executing `vite build`. Because `vite` and `@vitejs/plugin-react` are regular dependencies in `frontend/package.json`, Cloud Build always has the packages needed to compile the React app.
+Google Cloud Build triggers on pushes to `main` and orchestrates the entire deployment. It installs all backend, functions and frontend dependencies with `npm install`, then runs tests. The React app is compiled using `npm --prefix frontend run build` so the Vite build succeeds. After building, Cloud Build deploys Firebase functions with `firebase deploy --only functions` using the `firebase-ci-token` secret and finally updates the Cloud Run service via `gcloud run deploy`.

--- a/public/README.md
+++ b/public/README.md
@@ -113,10 +113,11 @@ On CI, auth is handled via `FIREBASE_TOKEN`.
 ### CI Deploys
 
 1. Generate a token locally using `firebase login:ci`.
-2. Store it as `FIREBASE_TOKEN` in your repository's GitHub Actions secrets (Settings > Secrets and variables > Actions). Alternatively, you can store it as
-   `firebase-ci-token` in Cloud Build's Secret Manager.
-3. The CI workflow injects this token so `firebase deploy` runs without
-   interactive login. If the token expires, re-run the command above.
+2. Store it as `firebase-ci-token` in Cloud Build's Secret Manager.
+3. Pushes to `main` trigger Cloud Build, which installs all dependencies,
+   runs tests, builds the frontend with Vite, deploys Firebase functions using
+   the token and then updates the Cloud Run service with
+   `gcloud run deploy`.
 
 ### Build Frontend for Hosting
 
@@ -128,8 +129,8 @@ npm run build --prefix frontend
 
 The command outputs static files in `frontend/build/`. Copy them to the repository's
 `public/` directory or set `hosting.public` in `firebase.json` to `frontend/build` so
-Firebase Hosting serves the build directory. Ensure these files are available before
-running:
+Firebase Hosting serves the build directory. Cloud Build executes this command
+automatically during CI, but you can run it manually before:
 
 ```bash
 firebase deploy


### PR DESCRIPTION
## Summary
- install frontend deps normally in Cloud Build
- deploy Firebase functions and Cloud Run from `main`
- clarify pipeline in docs
- note Cloud Build install behavior in README

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_686746067ed083239aa2fe8921414a88