### PR TITLE
Fix frontend build step

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -27,6 +27,11 @@ steps:
     timeout: 600s
 
   - name: 'gcr.io/cloud-builders/npm'
+    args: ['install', '--prefix', 'frontend']
+    id: Install frontend build deps
+    timeout: 600s
+
+  - name: 'gcr.io/cloud-builders/npm'
     args: ['--prefix', 'frontend', 'run', 'build']
     id: Build frontend
     timeout: 600s


### PR DESCRIPTION
## Summary
- ensure vite is installed before building the frontend in Cloud Build

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_686748ed7328832395a33705bd157534