### PR TITLE
fix(ci): enforce cloudbuild.yaml and document Cloud Build setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,33 @@ On CI, auth is handled via `FIREBASE_TOKEN`.
    the secret token and finally updates the Cloud Run service with
    `gcloud run deploy`.
 
+## 🔧 Cloud Build Setup
+
+This project uses a custom `cloudbuild.yaml` to deploy both Firebase Functions
+and Cloud Run services.
+
+### Prerequisites
+
+- Add the following secret to Secret Manager:
+  Name: firebase-ci-token
+  Value: [your Firebase CI token]
+- Grant access to the Cloud Build service account.
+- Link your GitHub repo to Google Cloud Build.
+
+### Trigger Configuration
+
+1. Go to **Cloud Build → Triggers**.
+2. Click **Create Trigger**.
+3. Choose:
+   - **Event:** Push to a branch
+   - **Branch:** `main`
+   - **Configuration:** Cloud Build configuration file
+   - **File location:** `/cloudbuild.yaml`
+   - **Service Account:** Use custom role with only required permissions
+4. Save the trigger.
+
+✅ Your deployments will now be fully managed through this YAML file.
+
 ### Build Frontend for Hosting
 
 Before deploying, create a production build of the React app. From the

--- a/cloudbuild.dev.yaml
+++ b/cloudbuild.dev.yaml
@@ -1,0 +1,8 @@
+# Dev trigger for local debugging
+steps:
+  - name: 'gcr.io/cloud-builders/gcloud'
+    entrypoint: bash
+    args:
+      - -c
+      - |
+          echo "\u2705 Cloud Build dev trigger executed"

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -13,6 +13,22 @@ steps:
     id: Install frontend packages
     timeout: 600s
 
+  # Validate required tooling
+  - name: node:20
+    entrypoint: bash
+    args:
+      - -c
+      - |
+          if ! command -v vite >/dev/null 2>&1; then
+            echo "\u274c vite is not installed. Add it to your devDependencies or install globally."
+            exit 1
+          fi
+          if ! command -v firebase >/dev/null 2>&1; then
+            echo "\u274c firebase-tools is not installed. Add it to your devDependencies or install globally."
+            exit 1
+          fi
+    id: Validate tooling
+
   # Build the frontend with Vite via root script
   - name: 'node:20'
     entrypoint: npm


### PR DESCRIPTION
## Summary
- add tooling validation step in `cloudbuild.yaml`
- document Cloud Build setup instructions in README
- provide a `cloudbuild.dev.yaml` example for local triggers

## Testing
- `npm ci`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_686761a549588323ba5e11a7603a37bf