### PR TITLE
Improve Cloud Build logging and troubleshooting

### DIFF
--- a/.github/workflows/cloud-run-deploy.yml
+++ b/.github/workflows/cloud-run-deploy.yml
@@ -14,6 +14,7 @@ jobs:
       GOOGLE_ENTRYPOINT: "node index.js"
       GOOGLE_NODE_RUN_SCRIPTS: build
       NODE_ENV: development
+      FIREBASE_TOKEN: ${{ secrets.FIREBASE_TOKEN }}
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
@@ -35,15 +36,10 @@ jobs:
         with:
           project_id: ${{ env.PROJECT_ID }}
           service_account_key: ${{ secrets.GCP_SA_KEY }}
-      - name: Deploy to Cloud Run
+      - name: Trigger Cloud Build
         run: |
-          gcloud run deploy $SERVICE_NAME \
-            --source . \
-            --region us-central1 \
-            --project $PROJECT_ID \
-            --timeout=300s \
-            --allow-unauthenticated \
-            --build-env-vars="GOOGLE_NODE_RUN_SCRIPTS=build,NODE_ENV=development"
+          gcloud builds submit --config cloudbuild.yaml \
+            --substitutions=_SERVICE_NAME=$SERVICE_NAME,_REGION=$GOOGLE_REGION
       - name: Verify Cloud Run healthcheck
         run: |
           status=$(curl -s -o /dev/null -w "%{http_code}" https://${{ env.SERVICE_NAME }}-${{ env.GOOGLE_REGION }}.a.run.app/healthcheck.html)

--- a/README.md
+++ b/README.md
@@ -245,6 +245,21 @@ commands again to ensure the dependency installed correctly.
 
 Both commands should exit without errors.
 
+## \U0001F527 Deployment Troubleshooting
+
+When deployments fail, first confirm `FIREBASE_TOKEN` and `PROJECT_ID` are
+defined in your Cloud Build trigger or GitHub workflow. Verify the service
+account used has permission to deploy Firebase functions and Cloud Run.
+
+Run a local test build with:
+
+```bash
+gcloud builds submit --config cloudbuild.yaml
+```
+
+Logs stream to **Cloud Logging** by default. If a `logsBucket` is configured,
+logs will also appear in that Cloud Storage bucket.
+
 ## Firebase Project Info
 
 - **Project Name:** Super Intelligence  

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -20,7 +20,7 @@ steps:
       - -c
       - |
           if ! command -v vite >/dev/null 2>&1; then
-            echo "\u274c vite is not installed. Add it to your devDependencies or install globally."
+            echo "\u274c vite is not installed. Run 'npm install -D vite' and try again."
             exit 1
           fi
           if ! command -v firebase >/dev/null 2>&1; then
@@ -28,6 +28,18 @@ steps:
             exit 1
           fi
     id: Validate tooling
+
+  # Fail early if required env vars aren't set
+  - name: node:20
+    entrypoint: bash
+    args:
+      - -c
+      - |
+          if [ -z "$FIREBASE_TOKEN" ] || [ -z "$PROJECT_ID" ]; then
+            echo "\u274c FIREBASE_TOKEN or PROJECT_ID not provided."
+            exit 1
+          fi
+    id: Check env
 
   # Build the frontend with Vite via root script
   - name: 'node:20'
@@ -43,21 +55,37 @@ steps:
       - -c
       - |
           npm install -g firebase-tools
-          firebase deploy --only functions --token "$FIREBASE_TOKEN" --project "$PROJECT_ID"
+          if firebase deploy --only functions --token "$FIREBASE_TOKEN" --project "$PROJECT_ID"; then
+            echo "\u2705 Functions deployed"
+          else
+            echo "\u274c Functions deployment failed"
+            exit 1
+          fi
     id: Deploy functions
     timeout: 1200s
 
   # Deploy Cloud Run service from container image (no Buildpacks)
   - name: 'gcr.io/cloud-builders/gcloud'
+    entrypoint: bash
     args:
-      - run
-      - deploy
-      - "$SERVICE_NAME"
-      - --image=gcr.io/$PROJECT_ID/$SERVICE_NAME
-      - --region=$REGION
+      - -c
+      - |
+          if gcloud run deploy "${_SERVICE_NAME}" --image=gcr.io/$PROJECT_ID/${_SERVICE_NAME} --region=${_REGION}; then
+            echo "\u2705 Cloud Run service deployed"
+          else
+            echo "\u274c Cloud Run deployment failed"
+            exit 1
+          fi
     id: Deploy service
 
 availableSecrets:
   secretManager:
     - versionName: projects/$PROJECT_ID/secrets/firebase-ci-token/versions/latest
       env: FIREBASE_TOKEN
+logsBucket: "${_LOGS_BUCKET}"
+options:
+  logging: CLOUD_LOGGING_ONLY
+substitutions:
+  _LOGS_BUCKET: ""
+  _SERVICE_NAME: ""
+  _REGION: ""


### PR DESCRIPTION
## Summary
- fail build early if `FIREBASE_TOKEN` or `PROJECT_ID` are missing
- show clearer errors when `vite` isn't installed
- log success/failure of Firebase functions and Cloud Run deploys
- default to `CLOUD_LOGGING_ONLY` logging with optional `logsBucket`
- trigger Cloud Build from GitHub workflow
- document deployment troubleshooting steps in README

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6867644f90348323a3af37d53cec33eb