### PR TITLE
Move ajv to devDependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,9 +7,7 @@
     "": {
       "name": "super-intelligence-app",
       "version": "1.0.0",
-      "hasInstallScript": true,
       "dependencies": {
-        "ajv": "^8.17.1",
         "eventsource": "^4.0.0",
         "express": "^4.18.2",
         "firebase": "^11.10.0",
@@ -19,6 +17,7 @@
         "ws": "^8.13.0"
       },
       "devDependencies": {
+        "ajv": "^8.17.1",
         "concurrently": "^9.2.0",
         "firebase-tools": "^13.0.0",
         "js-yaml": "^4.1.0"
@@ -2621,6 +2620,7 @@
       "version": "8.17.1",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
@@ -4597,6 +4597,7 @@
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/fast-fifo": {
@@ -4616,6 +4617,7 @@
     },
     "node_modules/fast-uri": {
       "version": "3.0.6",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -6606,6 +6608,7 @@
     },
     "node_modules/json-schema-traverse": {
       "version": "1.0.0",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/jsonfile": {
@@ -8465,6 +8468,7 @@
     },
     "node_modules/require-from-string": {
       "version": "2.0.2",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"

--- a/package.json
+++ b/package.json
@@ -24,13 +24,13 @@
     "firebase-admin": "^11.0.0",
     "firebase-functions": "^3.24.1",
     "jsdom": "^26.1.0",
-    "ajv": "^8.17.1",
     "ws": "^8.13.0"
   },
   "overrides": {
     "protobufjs": "^7.2.4"
   },
   "devDependencies": {
+    "ajv": "^8.17.1",
     "concurrently": "^9.2.0",
     "firebase-tools": "^13.0.0",
     "js-yaml": "^4.1.0"


### PR DESCRIPTION
## Summary
- move `ajv` from `dependencies` to `devDependencies`
- regenerate `package-lock.json`

## Testing
- `npm install`

------
https://chatgpt.com/codex/tasks/task_e_68676f87e5788323ad744a20ac16a12e