### PR TITLE
Add dependency validation step

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -8,6 +8,17 @@ steps:
     id: Install root deps
     timeout: 600s
 
+  # Validate dev dependencies required for tests
+  - name: 'node:20'
+    entrypoint: bash
+    args:
+      - -c
+      - |
+          npm ci
+          npm ls ajv >/dev/null 2>&1 || { echo "❌ ajv not installed"; exit 1; }
+    id: Validate test deps
+    timeout: 600s
+
   # Install Firebase Functions dependencies
   - name: 'node:20'
     entrypoint: npm


### PR DESCRIPTION
## Summary
- add `Validate test deps` step in Cloud Build
- check `ajv` dependency during CI

## Testing
- `npm test --silent` *(fails: Missing 'ajv')*

------
https://chatgpt.com/codex/tasks/task_e_68677089bbe0832381569794b33db5a6