### PR TITLE
Update README to note ajv requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ Inspired by principles from:
    ```
    Edit these files to include your Firebase config such as
    `VITE_FIREBASE_API_KEY`.
-5. Run tests from the repo root (requires functions dependencies):
+5. Run tests from the repo root (requires functions dependencies). The `ajv` package is a mandatory dev dependency and must be installed before running tests:
    ```bash
    npm test --silent
    ```


### PR DESCRIPTION
## Summary
- mention that `ajv` must be installed before running tests

## Testing
- `npm test --silent` *(fails: Missing 'ajv')*

------
https://chatgpt.com/codex/tasks/task_e_68677168bcac8323b3a7303fb39b712d