### PR TITLE
Enforce ajv dev dependency

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,31 @@
+name: AJV Lock
+
+on:
+  push:
+    paths:
+      - 'package.json'
+      - 'package-lock.json'
+      - 'scripts/checkDevDeps.js'
+      - '.github/workflows/main.yml'
+  pull_request:
+    paths:
+      - 'package.json'
+      - 'package-lock.json'
+      - 'scripts/checkDevDeps.js'
+      - '.github/workflows/main.yml'
+
+jobs:
+  cold-install-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Setup Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18
+      - name: Remove node_modules
+        run: rm -rf node_modules
+      - name: Install dependencies
+        run: npm ci
+      - name: Verify dev dependencies
+        run: node scripts/checkDevDeps.js

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # 🧠 Super-Intelligence
 
 [![Firebase CI/CD](https://github.com/yourusername/Super-Intelligence/actions/workflows/firebase.yml/badge.svg)](https://github.com/yourusername/Super-Intelligence/actions/workflows/firebase.yml)
+[![AJV Locked](https://github.com/yourusername/Super-Intelligence/actions/workflows/main.yml/badge.svg)](https://github.com/yourusername/Super-Intelligence/actions/workflows/main.yml)
 
 **Building ethical, human-centered superintelligence to empower individuals and transform global systems.**
 
@@ -245,6 +246,8 @@ commands again to ensure the dependency installed correctly.
 
 Both commands should exit without errors.
 
+- If `ajv` is not found during tests, re-run `npm ci` or `npm install` from the repository root to reinstall dev dependencies.
+
 ## \U0001F527 Deployment Troubleshooting
 
 When deployments fail, first confirm `FIREBASE_TOKEN` and `PROJECT_ID` are
@@ -259,6 +262,12 @@ gcloud builds submit --config cloudbuild.yaml
 
 Logs stream to **Cloud Logging** by default. If a `logsBucket` is configured,
 logs will also appear in that Cloud Storage bucket.
+
+### FAQ
+
+**Why do we use `ajv`?** It validates agent metadata against JSON schemas so tests can enforce correct structure.
+
+**Why is `ajv` mandatory?** Metadata validation and unit tests depend on it. Missing `ajv` will cause CI and local tests to fail.
 
 ## Firebase Project Info
 

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -8,15 +8,14 @@ steps:
     id: Install root deps
     timeout: 600s
 
-  # Validate dev dependencies required for tests
+  # Verify CI devDeps
   - name: 'node:20'
     entrypoint: bash
     args:
       - -c
       - |
-          npm ci
-          npm ls ajv >/dev/null 2>&1 || { echo "❌ ajv not installed"; exit 1; }
-    id: Validate test deps
+          node scripts/checkDevDeps.js
+    id: Verify CI devDeps
     timeout: 600s
 
   # Install Firebase Functions dependencies

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "start": "firebase emulators:start",
     "sync-agents": "node scripts/syncAgentsConfig.js",
-    "validate-metadata": "node scripts/validateAgentMetadata.js",
+    "validate-metadata": "node scripts/checkDevDeps.js && node scripts/validateAgentMetadata.js",
     "test": "if [ \"$TEST\" = \"false\" ]; then echo 'Skipping tests'; else node scripts/checkDevDeps.js && npm run sync-agents && node scripts/validateAgentMetadata.js && npm --prefix functions test --silent; fi",
     "dev": "npm --prefix frontend run dev",
     "build": "npm --prefix frontend run build",
@@ -35,5 +35,6 @@
     "concurrently": "^9.2.0",
     "firebase-tools": "^13.0.0",
     "js-yaml": "^4.1.0"
-  }
+  },
+  "ajvComment": "Required for validating agent metadata and tests"
 }

--- a/scripts/checkDevDeps.js
+++ b/scripts/checkDevDeps.js
@@ -1,12 +1,17 @@
 const { execSync } = require('child_process');
+const path = require('path');
+const fs = require('fs');
 
 function checkDevDeps() {
-  const devDeps = ['ajv'];
+  const pkgJson = JSON.parse(
+    fs.readFileSync(path.join(__dirname, '..', 'package.json'), 'utf8')
+  );
+  const devDeps = Object.keys(pkgJson.devDependencies || {});
   for (const pkg of devDeps) {
     try {
       execSync(`npm ls ${pkg}`, { stdio: 'ignore' });
     } catch (err) {
-      console.error(`\u274c Missing '${pkg}'. Run 'npm install --save-dev ${pkg}'`);
+      console.error(`\u274c Missing dev dependency '${pkg}'. Run 'npm install --save-dev ${pkg}'`);
       process.exit(1);
     }
   }


### PR DESCRIPTION
## Summary
- prevent tests from running if dev dependencies are missing
- add CI badge and FAQ explaining the mandatory ajv package
- document how to reinstall ajv when tests fail
- check all dev deps in `checkDevDeps.js`
- run dev dep check in Cloud Build
- create GitHub Action to verify cold installs

## Testing
- `npm test --silent`
- `node scripts/checkDevDeps.js`

------
https://chatgpt.com/codex/tasks/task_e_6867748620e083239e0f8d9b176368f6