### PR TITLE
Remove Cloud Build logsBucket conflict

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -106,13 +106,10 @@ availableSecrets:
     - versionName: projects/$PROJECT_ID/secrets/firebase-ci-token/versions/latest
       env: FIREBASE_TOKEN
 
-logsBucket: "${_LOGS_BUCKET}"
-
 options:
   logging: CLOUD_LOGGING_ONLY
 
 substitutions:
-  _LOGS_BUCKET: ""
   _SERVICE_NAME: ""
   _REGION: ""
 


### PR DESCRIPTION
## Summary
- drop `logsBucket` definition in Cloud Build config
- keep `options.logging: CLOUD_LOGGING_ONLY` so logs go to Cloud Logging by default

## Testing
- `npm ci`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686779784d508323882daa33342803f6