### PR TITLE
Harden cloud build secrets handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,14 +124,16 @@ To run Firebase Hosting locally and start the frontend app:
 If you're not logged into Firebase, it will prompt you.
 
 On CI, auth is handled via `FIREBASE_TOKEN`.
+If the token isn't provided, Cloud Build simply skips deploying
+Firebase functions and continues with the Cloud Run deploy.
 
 ### CI Deploys
 
 1. Generate a token locally using `firebase login:ci`.
 2. Store it as `firebase-ci-token` in Cloud Build's Secret Manager.
 3. Pushes to `main` trigger Cloud Build, which installs all dependencies,
-   runs tests, builds the frontend with Vite, deploys Firebase functions using
-   the secret token and finally updates the Cloud Run service with
+   runs tests, builds the frontend with Vite, and deploys Firebase functions
+   when the secret token is present before updating the Cloud Run service with
    `gcloud run deploy`.
 
 ## 🔧 Cloud Build Setup
@@ -252,9 +254,11 @@ Both commands should exit without errors.
 
 ## \U0001F527 Deployment Troubleshooting
 
-When deployments fail, first confirm `FIREBASE_TOKEN` and `PROJECT_ID` are
-defined in your Cloud Build trigger or GitHub workflow. Verify the service
-account used has permission to deploy Firebase functions and Cloud Run.
+When deployments fail, first confirm `PROJECT_ID` and other required
+variables are defined in your Cloud Build trigger or GitHub workflow.
+`FIREBASE_TOKEN` is optional—if it's missing the build skips the functions
+deploy step. Ensure the service account used has permission to deploy
+Firebase functions and Cloud Run.
 
 Run a local test build with:
 

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -33,16 +33,27 @@ steps:
           npx --yes firebase --version >/dev/null 2>&1 || { echo "❌ firebase-tools not found"; exit 1; }
     id: Validate tooling
 
-  # Fail early if required env vars aren't set
+  # Verify required env vars and warn if optional secrets are missing
   - name: node:20
     entrypoint: bash
     args:
       - -c
       - |
-          : "${FIREBASE_TOKEN:?FIREBASE_TOKEN not set}"
-          : "${PROJECT_ID:?PROJECT_ID not set}"
-          : "${_SERVICE_NAME:?_SERVICE_NAME not set}"
-          : "${_REGION:?_REGION not set}"
+          missing=0
+          for var in PROJECT_ID _SERVICE_NAME _REGION; do
+            if [ -z "${!var}" ]; then
+              echo "❌ $var not set"
+              missing=1
+            else
+              echo "✅ $var resolved"
+            fi
+          done
+          if [ -z "$FIREBASE_TOKEN" ]; then
+            echo "⚠️ FIREBASE_TOKEN not provided; functions deploy will be skipped"
+          else
+            echo "✅ FIREBASE_TOKEN resolved"
+          fi
+          [ $missing -eq 0 ] || exit 1
     id: Check env
 
   # Build the frontend with Vite via root script
@@ -52,18 +63,22 @@ steps:
     id: Build frontend
     timeout: 600s
 
-  # Deploy Firebase functions
+  # Deploy Firebase functions when token is available
   - name: 'node:20'
     entrypoint: bash
     args:
       - -c
       - |
-          npm install -g firebase-tools
-          if firebase deploy --only functions --token "$FIREBASE_TOKEN" --project "$PROJECT_ID"; then
-            echo "✅ Functions deployed"
+          if [ -z "$FIREBASE_TOKEN" ]; then
+            echo "⚠️ FIREBASE_TOKEN missing - skipping functions deploy"
           else
-            echo "❌ Functions deployment failed"
-            exit 1
+            npm install -g firebase-tools
+            if firebase deploy --only functions --token "$FIREBASE_TOKEN" --project "$PROJECT_ID"; then
+              echo "✅ Functions deployed"
+            else
+              echo "❌ Functions deployment failed"
+              exit 1
+            fi
           fi
     id: Deploy functions
     timeout: 1200s

--- a/docs/ci-workflows.md
+++ b/docs/ci-workflows.md
@@ -14,8 +14,8 @@ Each workflow automates part of the deploy or validation process.
 4. Run tests and build the project.
 5. Deploy to a preview Hosting channel with `firebase hosting:channel:deploy preview`.
 
-**Environment Variables**
-- `FIREBASE_TOKEN` &mdash; Firebase deploy token from secrets. Generate it with `firebase login:ci` and store the value under **Settings > Secrets and variables > Actions** in your GitHub repository.
+-**Environment Variables**
+- `FIREBASE_TOKEN` &mdash; Firebase deploy token from secrets. Generate it with `firebase login:ci` and store the value under **Settings > Secrets and variables > Actions** in your GitHub repository. If omitted, functions deploy is skipped.
 - `NODE_VERSION` &mdash; set to `18.x`.
 
 ## Firebase CI/CD (`firebase.yml`)
@@ -27,7 +27,7 @@ Each workflow automates part of the deploy or validation process.
 - `deploy` installs dependencies, validates agent metadata, runs lint and tests, verifies Hosting targets, installs the Firebase CLI, and deploys functions, hosting and Firestore.
 
 **Environment Variables**
-- `FIREBASE_TOKEN` &mdash; deploy token from secrets.
+- `FIREBASE_TOKEN` &mdash; deploy token from secrets. Optional; skip functions deploy if not provided.
 - `FIREBASE_PROJECT_ID` &mdash; Firebase project ID secret used during deploy.
 
 ## Firebase Config Validation (`firebase-validate.yml`)
@@ -63,4 +63,5 @@ The repository does not currently include separate `deploy-prod.yml` or `test-ag
 
 ## Cloud Build (`cloudbuild.yaml`)
 
-Google Cloud Build triggers on pushes to `main` and orchestrates the entire deployment. It installs all backend, functions and frontend dependencies with `npm install`, then runs tests. The React app is compiled using `npm --prefix frontend run build` so the Vite build succeeds. After building, Cloud Build deploys Firebase functions with `firebase deploy --only functions` using the `firebase-ci-token` secret and finally updates the Cloud Run service via `gcloud run deploy`.
+Google Cloud Build triggers on pushes to `main` and orchestrates the entire deployment. It installs all backend, functions and frontend dependencies with `npm install`, then runs tests. The React app is compiled using `npm --prefix frontend run build` so the Vite build succeeds. After building, Cloud Build deploys Firebase functions using the optional `firebase-ci-token` secret and finally updates the Cloud Run service via `gcloud run deploy`.
+If the token isn't configured, the functions deploy step is skipped.

--- a/public/README.md
+++ b/public/README.md
@@ -109,14 +109,16 @@ To run Firebase Hosting locally and start the frontend app:
 If you're not logged into Firebase, it will prompt you.
 
 On CI, auth is handled via `FIREBASE_TOKEN`.
+If the variable is unset, Cloud Build warns and skips deploying Firebase
+functions.
 
 ### CI Deploys
 
 1. Generate a token locally using `firebase login:ci`.
 2. Store it as `firebase-ci-token` in Cloud Build's Secret Manager.
 3. Pushes to `main` trigger Cloud Build, which installs all dependencies,
-   runs tests, builds the frontend with Vite, deploys Firebase functions using
-   the token and then updates the Cloud Run service with
+   runs tests, builds the frontend with Vite, and deploys Firebase functions
+   when the token is available before updating the Cloud Run service with
    `gcloud run deploy`.
 
 ### Build Frontend for Hosting


### PR DESCRIPTION
## Summary
- add safer env checks and skip functions deploy if `FIREBASE_TOKEN` missing
- document optional token across README files and workflows
- update CI docs with secret fallback details

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68677b35d36c8323aa3e366ed806e999