### PR TITLE
Fix cloudbuild YAML syntax

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -48,14 +48,11 @@ steps:
               echo "✅ $var resolved"
             fi
           done
-if [ -n "${_FIREBASE_TOKEN:-}" ]; then
-  FIREBASE_TOKEN="${_FIREBASE_TOKEN}"
-fi
-if [ -z "$FIREBASE_TOKEN" ]; then
-  echo "⚠️ _FIREBASE_TOKEN not provided; functions deploy will be skipped"
-else
-  echo "✅ _FIREBASE_TOKEN resolved"
-fi
+          if [ -n "${_FIREBASE_TOKEN:-}" ]; then
+            FIREBASE_TOKEN="${_FIREBASE_TOKEN}"
+          fi
+          if [ -z "$FIREBASE_TOKEN" ]; then
+            echo "⚠️ _FIREBASE_TOKEN not provided; functions deploy will be skipped"
           else
             echo "✅ _FIREBASE_TOKEN resolved"
           fi
@@ -75,12 +72,11 @@ fi
     args:
       - -c
       - |
-if [ -n "${_FIREBASE_TOKEN:-}" ]; then
-  FIREBASE_TOKEN="${_FIREBASE_TOKEN}"
-fi
-if [ -z "$FIREBASE_TOKEN" ]; then
-  echo "⚠️ _FIREBASE_TOKEN missing - skipping functions deploy"
-
+          if [ -n "${_FIREBASE_TOKEN:-}" ]; then
+            FIREBASE_TOKEN="${_FIREBASE_TOKEN}"
+          fi
+          if [ -z "$FIREBASE_TOKEN" ]; then
+            echo "⚠️ _FIREBASE_TOKEN missing - skipping functions deploy"
           else
             npm install -g firebase-tools
             if firebase deploy --only functions --token "${_FIREBASE_TOKEN}" --project "$PROJECT_ID"; then


### PR DESCRIPTION
## Summary
- fix YAML indentation around FIREBASE_TOKEN checks
- fix indentation for deploy functions step

## Testing
- `npm test`
- `python3 - <<'PY'
import yaml; yaml.safe_load(open('cloudbuild.yaml')); print('ok')
PY`

------
https://chatgpt.com/codex/tasks/task_e_686784465598832389a26d3d1dcf90e7