### PR TITLE
Fix Cloud Build token secret usage

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -132,5 +132,4 @@ options:
 substitutions:
   _SERVICE_NAME: ""
   _REGION: ""
-  _FIREBASE_TOKEN: ""
 


### PR DESCRIPTION
## Summary
- remove `_FIREBASE_TOKEN` from custom substitutions
- rely on the `firebase-ci-token` secret and assign it to `FIREBASE_TOKEN` if present

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_686786579da48323875b830c539f6842