### PR TITLE
Fix Firebase token usage and harden Cloud Build

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,13 +1,10 @@
 steps:
-  # Cloud Build logs stdout/stderr from each step by default
-
   # Install root dependencies using Node.js 20
   - name: 'node:20'
     entrypoint: npm
     args: ['ci']
     id: Install root deps
     timeout: 600s
-
 
   # Install Firebase Functions dependencies
   - name: 'node:20'
@@ -33,7 +30,7 @@ steps:
           npx --yes firebase --version >/dev/null 2>&1 || { echo "❌ firebase-tools not found"; exit 1; }
     id: Validate tooling
 
-  # Verify required env vars and warn if optional secrets are missing
+  # Verify required env vars and optional secrets
   - name: node:20
     entrypoint: bash
     args:
@@ -49,12 +46,15 @@ steps:
             fi
           done
           if [ -n "${_FIREBASE_TOKEN:-}" ]; then
-            FIREBASE_TOKEN="${_FIREBASE_TOKEN}"
+            export FIREBASE_TOKEN="${_FIREBASE_TOKEN}"
           fi
           if [ -z "$FIREBASE_TOKEN" ]; then
             echo "⚠️ _FIREBASE_TOKEN not provided; functions deploy will be skipped"
           else
             echo "✅ _FIREBASE_TOKEN resolved"
+          fi
+          if [ "${SKIP_DEPLOY}" = "true" ]; then
+            echo "⚠️ SKIP_DEPLOY enabled - deploy steps will be skipped"
           fi
           [ $missing -eq 0 ] || exit 1
     id: Check env
@@ -72,14 +72,18 @@ steps:
     args:
       - -c
       - |
+          if [ "${SKIP_DEPLOY}" = "true" ]; then
+            echo "⚠️ SKIP_DEPLOY=true - skipping functions deploy"
+            exit 0
+          fi
           if [ -n "${_FIREBASE_TOKEN:-}" ]; then
-            FIREBASE_TOKEN="${_FIREBASE_TOKEN}"
+            export FIREBASE_TOKEN="${_FIREBASE_TOKEN}"
           fi
           if [ -z "$FIREBASE_TOKEN" ]; then
-            echo "⚠️ _FIREBASE_TOKEN missing - skipping functions deploy"
+            echo "⚠️ No firebase token - skipping functions deploy"
           else
             npm install -g firebase-tools
-            if firebase deploy --only functions --token "${_FIREBASE_TOKEN}" --project "$PROJECT_ID"; then
+            if firebase deploy --only functions --token "$FIREBASE_TOKEN" --project "$PROJECT_ID"; then
               echo "✅ Functions deployed"
             else
               echo "❌ Functions deployment failed"
@@ -89,12 +93,16 @@ steps:
     id: Deploy functions
     timeout: 1200s
 
-  # Deploy Cloud Run service from container image (no Buildpacks)
+  # Deploy Cloud Run service from container image
   - name: 'gcr.io/cloud-builders/gcloud'
     entrypoint: bash
     args:
       - -c
       - |
+          if [ "${SKIP_DEPLOY}" = "true" ]; then
+            echo "⚠️ SKIP_DEPLOY=true - skipping Cloud Run deploy"
+            exit 0
+          fi
           if gcloud run deploy "${_SERVICE_NAME}" --image=gcr.io/$PROJECT_ID/${_SERVICE_NAME} --region=${_REGION}; then
             echo "✅ Cloud Run service deployed"
           else
@@ -103,12 +111,16 @@ steps:
           fi
     id: Deploy service
 
-  # Verify health endpoint after deploy and create uptime checks
+  # Verify health endpoint and create uptime checks
   - name: 'gcr.io/cloud-builders/gcloud'
     entrypoint: bash
     args:
       - -c
       - |
+          if [ "${SKIP_DEPLOY}" = "true" ]; then
+            echo "⚠️ SKIP_DEPLOY=true - skipping uptime checks"
+            exit 0
+          fi
           curl -f https://$SERVICE_NAME-$REGION.a.run.app/healthz
           gcloud monitoring uptime-checks create http cloud-run-health \
             --http-path=/healthz \


### PR DESCRIPTION
## Summary
- handle firebase token via secret manager
- skip Firebase deploy gracefully when token missing
- add `SKIP_DEPLOY` option for dry runs
- improve logging and checks in Cloud Build

## Testing
- `python3 - <<'EOF'
import yaml
yaml.safe_load(open('cloudbuild.yaml'))
print('YAML OK')
EOF`

------
https://chatgpt.com/codex/tasks/task_e_6867881a7b448323b55507ce76f75f19