### PR TITLE
Fix Firebase token handling in Cloud Build

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,11 +123,11 @@ To run Firebase Hosting locally and start the frontend app:
 ```
 If you're not logged into Firebase, it will prompt you.
 
-On CI, auth is handled via the `_FIREBASE_TOKEN` substitution.
-If neither `_FIREBASE_TOKEN` nor `FIREBASE_TOKEN` are provided, Cloud Build
-skips deploying Firebase functions and continues with the Cloud Run deploy.
-GitHub Actions will also look for `FIREBASE_TOKEN` in a local `.env` file when
-the secret isn't configured and will print a warning if it remains unset.
+On CI, Cloud Build loads `FIREBASE_TOKEN` from Secret Manager.
+If the secret is not configured, Cloud Build skips deploying Firebase functions
+and continues with the Cloud Run deploy.
+GitHub Actions uses the same secret, or reads `FIREBASE_TOKEN` from a local
+`.env` file when the secret isn't set and prints a warning otherwise.
 
 
 ### CI Deploys
@@ -259,7 +259,7 @@ Both commands should exit without errors.
 
 When deployments fail, first confirm `PROJECT_ID` and other required
 variables are defined in your Cloud Build trigger or GitHub workflow.
-`_FIREBASE_TOKEN` (or `FIREBASE_TOKEN`) is optional — if it's missing, the build skips the functions deploy step. Ensure the service account used has permission to deploy Firebase functions and Cloud Run.
+`FIREBASE_TOKEN` is optional — if it's missing, the build skips the functions deploy step. Ensure the service account used has permission to deploy Firebase functions and Cloud Run.
 
 Firebase functions and Cloud Run.
 

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -26,6 +26,7 @@ steps:
     args:
       - -c
       - |
+          set -euo pipefail
           npx --yes vite --version >/dev/null 2>&1 || { echo "❌ vite not found"; exit 1; }
           npx --yes firebase --version >/dev/null 2>&1 || { echo "❌ firebase-tools not found"; exit 1; }
     id: Validate tooling
@@ -36,6 +37,7 @@ steps:
     args:
       - -c
       - |
+          set -euo pipefail
           missing=0
           for var in PROJECT_ID _SERVICE_NAME _REGION; do
             if [ -z "${!var}" ]; then
@@ -45,15 +47,12 @@ steps:
               echo "✅ $var resolved"
             fi
           done
-          if [ -n "${_FIREBASE_TOKEN:-}" ]; then
-            export FIREBASE_TOKEN="${_FIREBASE_TOKEN}"
-          fi
-          if [ -z "$FIREBASE_TOKEN" ]; then
-            echo "⚠️ _FIREBASE_TOKEN not provided; functions deploy will be skipped"
+          if [ -z "${FIREBASE_TOKEN:-}" ]; then
+            echo "⚠️ FIREBASE_TOKEN not provided; functions deploy will be skipped"
           else
-            echo "✅ _FIREBASE_TOKEN resolved"
+            echo "✅ FIREBASE_TOKEN resolved"
           fi
-          if [ "${SKIP_DEPLOY}" = "true" ]; then
+          if [ "${SKIP_DEPLOY:-}" = "true" ]; then
             echo "⚠️ SKIP_DEPLOY enabled - deploy steps will be skipped"
           fi
           [ $missing -eq 0 ] || exit 1
@@ -72,14 +71,12 @@ steps:
     args:
       - -c
       - |
-          if [ "${SKIP_DEPLOY}" = "true" ]; then
+          set -euo pipefail
+          if [ "${SKIP_DEPLOY:-}" = "true" ]; then
             echo "⚠️ SKIP_DEPLOY=true - skipping functions deploy"
             exit 0
           fi
-          if [ -n "${_FIREBASE_TOKEN:-}" ]; then
-            export FIREBASE_TOKEN="${_FIREBASE_TOKEN}"
-          fi
-          if [ -z "$FIREBASE_TOKEN" ]; then
+          if [ -z "${FIREBASE_TOKEN:-}" ]; then
             echo "⚠️ No firebase token - skipping functions deploy"
           else
             npm install -g firebase-tools
@@ -99,7 +96,8 @@ steps:
     args:
       - -c
       - |
-          if [ "${SKIP_DEPLOY}" = "true" ]; then
+          set -euo pipefail
+          if [ "${SKIP_DEPLOY:-}" = "true" ]; then
             echo "⚠️ SKIP_DEPLOY=true - skipping Cloud Run deploy"
             exit 0
           fi
@@ -117,7 +115,8 @@ steps:
     args:
       - -c
       - |
-          if [ "${SKIP_DEPLOY}" = "true" ]; then
+          set -euo pipefail
+          if [ "${SKIP_DEPLOY:-}" = "true" ]; then
             echo "⚠️ SKIP_DEPLOY=true - skipping uptime checks"
             exit 0
           fi
@@ -137,7 +136,7 @@ steps:
 availableSecrets:
   secretManager:
     - versionName: projects/$PROJECT_ID/secrets/firebase-ci-token/versions/latest
-      env: _FIREBASE_TOKEN
+      env: FIREBASE_TOKEN
 options:
   logging: CLOUD_LOGGING_ONLY
 

--- a/docs/ci-workflows.md
+++ b/docs/ci-workflows.md
@@ -15,8 +15,7 @@ Each workflow automates part of the deploy or validation process.
 5. Deploy to a preview Hosting channel with `firebase hosting:channel:deploy preview`.
 
 -**Environment Variables**
-- `_FIREBASE_TOKEN` &mdash; Firebase deploy token from secrets passed as a custom substitution. Generate it with `firebase login:ci` and store the value under **Settings > Secrets and variables > Actions** in your GitHub repository. If omitted, functions deploy is skipped.
-- If the secret isn't defined, workflows read `FIREBASE_TOKEN` from a local `.env` file when present and warn otherwise.
+- `FIREBASE_TOKEN` &mdash; Firebase deploy token retrieved from repository secrets. Generate it with `firebase login:ci` and store the value under **Settings > Secrets and variables > Actions**. If the secret isn't defined, workflows read `FIREBASE_TOKEN` from a local `.env` file and warn if absent. Functions deploy is skipped when the token is missing.
 
 - `NODE_VERSION` &mdash; set to `18.x`.
 
@@ -29,8 +28,7 @@ Each workflow automates part of the deploy or validation process.
 - `deploy` installs dependencies, validates agent metadata, runs lint and tests, verifies Hosting targets, installs the Firebase CLI, and deploys functions, hosting and Firestore.
 
 **Environment Variables**
-- `_FIREBASE_TOKEN` &mdash; deploy token from secrets. Optional; skip functions deploy if not provided.
-- If unset, the CI job looks for `FIREBASE_TOKEN` in `.env`.
+- `FIREBASE_TOKEN` &mdash; deploy token from repository secrets. Optional; functions deploy is skipped if the token is not provided. If unset, the CI job looks for `FIREBASE_TOKEN` in `.env`.
 
 - `FIREBASE_PROJECT_ID` &mdash; Firebase project ID secret used during deploy.
 

--- a/public/README.md
+++ b/public/README.md
@@ -108,9 +108,8 @@ To run Firebase Hosting locally and start the frontend app:
 ```
 If you're not logged into Firebase, it will prompt you.
 
-On CI, auth is handled via the `_FIREBASE_TOKEN` secret.
-If neither `_FIREBASE_TOKEN` nor `FIREBASE_TOKEN` are set, Cloud Build warns and
-skips deploying Firebase functions.
+On CI, Cloud Build reads `FIREBASE_TOKEN` from Secret Manager.
+If the token is missing, Cloud Build warns and skips deploying Firebase functions.
 
 ### CI Deploys
 


### PR DESCRIPTION
## Summary
- secure Firebase token by loading from Secret Manager
- clarify token usage docs
- require bash safety flags in Cloud Build steps

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_686789f71ccc8323a5ff7a57346075e9