### PR TITLE
Fix Cloud Build token handling

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -47,16 +47,23 @@ steps:
               echo "✅ $var resolved"
             fi
           done
-          if [ -z "${FIREBASE_TOKEN:-}" ]; then
-            echo "⚠️ FIREBASE_TOKEN not provided; functions deploy will be skipped"
+          if [ -z "${_FIREBASE_TOKEN:-}" ]; then
+            echo "⚠️ _FIREBASE_TOKEN not provided; functions deploy will be skipped"
           else
-            echo "✅ FIREBASE_TOKEN resolved"
+            echo "✅ _FIREBASE_TOKEN resolved"
           fi
           if [ "${SKIP_DEPLOY:-}" = "true" ]; then
             echo "⚠️ SKIP_DEPLOY enabled - deploy steps will be skipped"
           fi
           [ $missing -eq 0 ] || exit 1
     id: Check env
+
+  # Run tests before deployment
+  - name: 'node:20'
+    entrypoint: npm
+    args: ['test', '--silent']
+    id: Run tests
+    timeout: 600s
 
   # Build the frontend with Vite via root script
   - name: 'node:20'
@@ -76,11 +83,11 @@ steps:
             echo "⚠️ SKIP_DEPLOY=true - skipping functions deploy"
             exit 0
           fi
-          if [ -z "${FIREBASE_TOKEN:-}" ]; then
+          if [ -z "${_FIREBASE_TOKEN:-}" ]; then
             echo "⚠️ No firebase token - skipping functions deploy"
           else
             npm install -g firebase-tools
-            if firebase deploy --only functions --token "$FIREBASE_TOKEN" --project "$PROJECT_ID"; then
+            if firebase deploy --only functions --token "$_FIREBASE_TOKEN" --project "$PROJECT_ID"; then
               echo "✅ Functions deployed"
             else
               echo "❌ Functions deployment failed"
@@ -120,23 +127,23 @@ steps:
             echo "⚠️ SKIP_DEPLOY=true - skipping uptime checks"
             exit 0
           fi
-          curl -f https://$SERVICE_NAME-$REGION.a.run.app/healthz
+          curl -f https://${_SERVICE_NAME}-${_REGION}.a.run.app/healthz
           gcloud monitoring uptime-checks create http cloud-run-health \
             --http-path=/healthz \
             --display-name="cloud-run-health" \
             --project=$PROJECT_ID \
-            --hostname="$SERVICE_NAME-$REGION.a.run.app" || true
+            --hostname="${_SERVICE_NAME}-${_REGION}.a.run.app" || true
           gcloud monitoring uptime-checks create http functions-health \
             --http-path=/healthz \
             --display-name="functions-health" \
             --project=$PROJECT_ID \
-            --hostname="$REGION-$PROJECT_ID.cloudfunctions.net" || true
+            --hostname="${_REGION}-${PROJECT_ID}.cloudfunctions.net" || true
     id: Setup uptime checks
 
 availableSecrets:
   secretManager:
     - versionName: projects/$PROJECT_ID/secrets/firebase-ci-token/versions/latest
-      env: FIREBASE_TOKEN
+      env: _FIREBASE_TOKEN
 options:
   logging: CLOUD_LOGGING_ONLY
 

--- a/public/README.md
+++ b/public/README.md
@@ -108,13 +108,21 @@ To run Firebase Hosting locally and start the frontend app:
 ```
 If you're not logged into Firebase, it will prompt you.
 
-On CI, Cloud Build reads `FIREBASE_TOKEN` from Secret Manager.
+On CI, Cloud Build reads `_FIREBASE_TOKEN` from Secret Manager.
 If the token is missing, Cloud Build warns and skips deploying Firebase functions.
 
 ### CI Deploys
 
 1. Generate a token locally using `firebase login:ci`.
-2. Store it as `firebase-ci-token` in Cloud Build's Secret Manager.
+2. Store it as `firebase-ci-token` in Secret Manager and grant Cloud Build access:
+   ```bash
+   gcloud secrets create firebase-ci-token --replication-policy=automatic
+   printf '%s' "$FIREBASE_TOKEN" | \
+     gcloud secrets versions add firebase-ci-token --data-file=-
+   gcloud secrets add-iam-policy-binding firebase-ci-token \
+     --member="serviceAccount:$PROJECT_ID@cloudbuild.gserviceaccount.com" \
+     --role="roles/secretmanager.secretAccessor"
+   ```
 3. Pushes to `main` trigger Cloud Build, which installs all dependencies,
    runs tests, builds the frontend with Vite, and deploys Firebase functions
    when the token is available before updating the Cloud Run service with


### PR DESCRIPTION
## Summary
- pull Firebase CI token from Secret Manager as `_FIREBASE_TOKEN`
- skip functions deploy if token absent
- run tests before deployment
- document secret creation in README and ci-workflows

## Testing
- `npm ci --silent`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68678c91b1fc832394eb0f9eab15f49f